### PR TITLE
docs: correct setup.sh description - it's not legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,25 +14,27 @@ Download and run: python setup-smart.py "[project purpose]"
 Then read CLAUDE.md and run the repository health check to verify main branch protection.
 ```
 
-### For Humans (Smart Setup)
+### For Humans (One-liner Setup)
 ```bash
-# Download smart setup script
-curl -sSL https://raw.githubusercontent.com/SteveGJones/ai-first-sdlc-practices/main/setup-smart.py > setup-smart.py
-
-# Run with your project purpose
-python setup-smart.py "building a REST API with FastAPI"
-
-# This will:
-# 1. Download enhanced CLAUDE.md with branch protection education
-# 2. Set up branch protection using gh CLI (prompts for auth if needed)
-# 3. Create all necessary directories and templates
-# 4. Generate initial feature proposal on ai-first-kick-start branch
-```
-
-### Legacy One-liner (if setup.sh exists)
-```bash
+# Quick setup with curl (recommended)
 curl -L https://raw.githubusercontent.com/SteveGJones/ai-first-sdlc-practices/main/setup.sh | bash -s -- "building a REST API"
+
+# Or without project purpose (uses default)
+curl -L https://raw.githubusercontent.com/SteveGJones/ai-first-sdlc-practices/main/setup.sh | bash
 ```
+
+### Alternative: Direct Python Setup
+```bash
+# If you prefer to download and run manually
+curl -sSL https://raw.githubusercontent.com/SteveGJones/ai-first-sdlc-practices/main/setup-smart.py > setup-smart.py
+python setup-smart.py "building a REST API with FastAPI"
+```
+
+Both methods will:
+1. Download enhanced CLAUDE.md with branch protection education
+2. Set up branch protection using gh CLI (prompts for auth if needed)
+3. Create all necessary directories and templates
+4. Generate initial feature proposal on ai-first-kick-start branch
 
 ### What This Does
 1. **Downloads enhanced CLAUDE.md** with branch protection education for AI agents

--- a/retrospectives/01-cicd-platform-rules.md
+++ b/retrospectives/01-cicd-platform-rules.md
@@ -224,3 +224,16 @@ This removes the need for multiple human prompts and ensures consistent applicat
 - Removed unnecessary code that could introduce future vulnerabilities
 
 **Remaining Alerts**: 32 notes (mostly unused imports and broad exception handling) - lower priority, non-security issues.
+
+### Documentation Correction
+
+**Incorrect "Legacy" Label**: During documentation updates, I incorrectly labeled `setup.sh` as "legacy". This was a misunderstanding.
+
+**Actual Purpose of setup.sh**:
+- It's the **primary entry point** for the one-liner installation
+- Acts as a wrapper that downloads and runs `setup-smart.py`
+- Provides prerequisite checks (Python 3, Git)
+- Handles the curl pipe to bash workflow that users expect
+- NOT legacy - it's the recommended installation method
+
+**Correction Applied**: Updated README.md to properly present `setup.sh` as the recommended one-liner setup method, with direct Python setup as an alternative.


### PR DESCRIPTION
setup.sh is the primary entry point for one-liner installation:
- Wrapper script that downloads and runs setup-smart.py
- Provides prerequisite checks (Python 3, Git, gh CLI)
- Handles curl pipe to bash workflow
- Recommended installation method, not legacy

Updated README to properly present setup.sh as the main installation method.

🤖 Generated with [Claude Code](https://claude.ai/code)