### PR TITLE
fix: resolve YAML formatting errors in CI/CD examples

### DIFF
--- a/examples/ci-cd/.github/workflows/ai-sdlc.yml
+++ b/examples/ci-cd/.github/workflows/ai-sdlc.yml
@@ -1,34 +1,35 @@
+---
 name: AI-First SDLC Validation
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   validate:
     runs-on: ubuntu-latest
-    
+
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.9'
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install pre-commit
-    
-    - name: Run validation pipeline
-      run: python tools/validate-pipeline.py --ci
-    
-    - name: Check feature proposal
-      run: python tools/check-feature-proposal.py
-    
-    - name: Run pre-commit hooks
-      run: pre-commit run --all-files
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pre-commit
+
+      - name: Run validation pipeline
+        run: python tools/validate-pipeline.py --ci
+
+      - name: Check feature proposal
+        run: python tools/check-feature-proposal.py
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files

--- a/examples/ci-cd/azure-devops/azure-pipelines.yml
+++ b/examples/ci-cd/azure-devops/azure-pipelines.yml
@@ -1,3 +1,4 @@
+---
 # AI-First SDLC Azure DevOps Pipeline
 # Enforces AI-First SDLC practices in Azure DevOps
 

--- a/examples/ci-cd/circleci/.circleci/config.yml
+++ b/examples/ci-cd/circleci/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 # AI-First SDLC CircleCI Configuration
 # Enforces AI-First SDLC practices in CircleCI
 

--- a/examples/ci-cd/gitlab/.gitlab-ci.yml
+++ b/examples/ci-cd/gitlab/.gitlab-ci.yml
@@ -1,3 +1,4 @@
+---
 # AI-First SDLC GitLab CI Pipeline
 # This pipeline enforces AI-First SDLC practices for GitLab projects
 

--- a/retrospectives/01-cicd-platform-rules.md
+++ b/retrospectives/01-cicd-platform-rules.md
@@ -415,3 +415,21 @@ This completes the framework's evolution from human-assisted to fully AI-autonom
 - ✅ Feature proposals show correct workflow
 
 **Key Insight**: Consistency across all documentation is critical for both human developers and AI agents to follow the correct workflow.
+
+### YAML Formatting Fixes for CI/CD Examples
+
+**Error Reported**: yamllint validation failures in example CI/CD configurations.
+
+**Issues Fixed**:
+1. **Missing document start**: Added `---` at the beginning of all YAML files
+2. **Bracket spacing**: Changed `[ main, develop ]` to `[main, develop]`
+3. **Indentation**: Fixed steps indentation from 4 spaces to 6 spaces under jobs
+4. **Trailing spaces**: Removed all trailing whitespace
+
+**Files Updated**:
+- examples/ci-cd/.github/workflows/ai-sdlc.yml
+- examples/ci-cd/gitlab/.gitlab-ci.yml
+- examples/ci-cd/azure-devops/azure-pipelines.yml
+- examples/ci-cd/circleci/.circleci/config.yml
+
+**Key Learning**: Example files should follow strict YAML linting rules as they serve as templates for users.


### PR DESCRIPTION
Fixed yamllint validation failures in all example CI/CD configurations:

- Added document start marker (---) to all YAML files
- Fixed bracket spacing: [main, develop] instead of [ main, develop ]
- Corrected indentation for GitHub Actions (6 spaces for steps)
- Removed all trailing whitespace

This ensures example files pass strict YAML validation and serve as proper templates for users.

🤖 Generated with [Claude Code](https://claude.ai/code)