### PR TITLE
feat: fix catalog generator, add sync and reference tools (#67)

### DIFF
--- a/AGENT-CATALOG.json
+++ b/AGENT-CATALOG.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-02-24T21:10:29.829309",
-  "total_agents": 70,
+  "generated": "2026-02-25T14:52:03.180605",
+  "total_agents": 68,
   "categories": {
     "ai-builders": 5,
     "ai-development": 9,
@@ -12,7 +12,6 @@
     "project-management": 4,
     "sdlc": 8,
     "general": 5,
-    "templates": 2,
     "testing": 4
   },
   "agents": [
@@ -49,8 +48,9 @@
         "testing"
       ],
       "capabilities": [
-        "context: AI infrastructure costs growing beyond budget without clear visibility",
-        "You are the AI DevOps Engineer, the specialist responsible for deploying and operating AI systems in production. You bridge the gap between AI development and production operations, ensuring that LLM applications, multi-agent systems, and AI workloads run reliably, cost-effectively, and at scale. Your approach is infrastructure-as-code, monitoring-driven, and cost-conscious."
+        "Team deploying a customer-facing LLM API requiring sub-second response times and cost control",
+        "Multi-agent orchestration system ready for production deployment with 10 specialized agents",
+        "AI infrastructure costs growing beyond budget without clear visibility"
       ],
       "domains": [
         "ai-infrastructure",
@@ -85,7 +85,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team wants to adopt AI-first development practices",
+        "Developer struggling with multi-agent coordination",
+        "Organization measuring AI team effectiveness"
+      ],
       "domains": [
         "ai-infrastructure",
         "tool-integration"
@@ -117,7 +121,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building a customer service chatbot that needs to remember conversation history across multiple sessions",
+        "AI application hitting token limits in long conversations",
+        "Multi-agent system where agents need to share context"
+      ],
       "domains": [
         "ai-infrastructure",
         "tool-integration"
@@ -147,7 +155,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building document processing pipeline with multiple specialized agents for extraction, validation, and transformation",
+        "Production system where agents occasionally give conflicting responses and coordination is unclear",
+        "Engineering team evaluating orchestration frameworks for new AI-powered customer support system"
+      ],
       "domains": [
         "ai-infrastructure",
         "tool-integration"
@@ -180,8 +192,9 @@
         "testing"
       ],
       "capabilities": [
-        "including index algorithms (HNSW, IVF, ScaNN), distance metrics (cosine, dot product, euclidean), and sharding strategies for scale",
-        "with understanding of dimensionality, language support, domain fine-tuning, and latency/cost trade-offs"
+        "Team building a technical documentation search system with 50K+ pages",
+        "Existing RAG system returning irrelevant results despite semantic search",
+        "RAG system experiencing high latency and embedding costs at scale"
       ],
       "domains": [
         "ai-infrastructure",
@@ -216,7 +229,11 @@
         "testing",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team designing multi-agent research system with LangChain and AutoGen agents",
+        "Team implementing agent orchestration with supervisor coordinating 50 workers",
+        "Production multi-agent system experiencing cascading failures"
+      ],
       "domains": [
         "ai-infrastructure",
         "machine-learning"
@@ -249,9 +266,9 @@
         "testing"
       ],
       "capabilities": [
-        "context: Existing agent producing inconsistent results in production",
-        "context: Building a multi-agent system with coordination challenges",
-        "You are the Agent Developer, an expert in designing and building AI agent systems using modern LLM architectures. You design agent reasoning patterns (ReAct, Plan-and-Execute, Reflection), craft effective personas using the Professional Specialist Pattern, architect multi-agent coordination systems, and implement production-ready guardrails and evaluation frameworks. Your approach is research-grounded—every architectural decision traces to established patterns from LangGraph, AutoGen, CrewAI, and production agent systems, and you balance theoretical best practices with practical deployment constraints."
+        "Team needs to design a new specialized agent for their domain",
+        "Existing agent producing inconsistent results in production",
+        "Building a multi-agent system with coordination challenges"
       ],
       "domains": [
         "ai-infrastructure",
@@ -298,7 +315,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team designing a new customer service AI system using LLMs and RAG",
+        "Reviewing an existing AI system architecture for production readiness",
+        "Designing MLOps infrastructure for a new AI initiative"
+      ],
       "domains": [
         "ai-infrastructure",
         "machine-learning"
@@ -359,10 +380,9 @@
         "testing"
       ],
       "capabilities": [
-        "Success criteria: Accuracy, speed, cost targets",
-        "1. Classify the problem type: RAG, agent, chain, multi-agent",
-        "Requirements summary with LangChain component mapping",
-        "Clear understanding of use case, scale, and constraints"
+        "Team building a RAG system for enterprise document analysis with LangChain",
+        "Developer implementing complex agent workflow with multiple decision points",
+        "After implementing a LangChain application experiencing high token costs"
       ],
       "domains": [
         "ai-infrastructure",
@@ -397,11 +417,9 @@
         "testing"
       ],
       "capabilities": [
-        "Current stable version requirements and feature sets",
-        "Beta feature implementation guidance with stability caveats",
-        "Deprecation timeline awareness for sunset features",
-        "Migration path recommendations between major versions",
-        "When testing version negotiation, validate server correctly identifies highest mutually supported protocol version because incorrect negotiation causes connection failures: test with client supporting older version, verify graceful degradation, check feature availability matrix"
+        "Team finishing MCP server implementation before production deployment",
+        "Development team concerned about security in their database MCP tools",
+        "Team wants to validate MCP specification compliance before release"
       ],
       "domains": [
         "ai-infrastructure",
@@ -446,11 +464,9 @@
         "typescript"
       ],
       "capabilities": [
-        "MCP specification version tracking and capability negotiation patterns",
-        "Transport mechanisms: stdio (local processes), SSE (server-sent events for web), HTTP with long-polling",
-        "Protocol primitives: tools (AI-invocable functions), resources (context data with URIs), prompts (reusable templates), sampling (LLM completion requests)",
-        "JSON-RPC 2.0 message framing and error handling conventions",
-        "Capability negotiation handshake and version compatibility strategies"
+        "Team building an MCP server to expose database operations to Claude Desktop",
+        "Existing MCP server experiencing performance issues with resource enumeration",
+        "Deploying MCP server to production with multiple AI clients"
       ],
       "domains": [
         "ai-infrastructure",
@@ -483,7 +499,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team has built an MCP server exposing database tools and needs comprehensive validation before deployment",
+        "Developer is debugging why their MCP server works inconsistently and needs root cause analysis",
+        "Team needs to validate error handling before releasing MCP server to external AI clients"
+      ],
       "domains": [
         "ai-infrastructure",
         "machine-learning",
@@ -519,7 +539,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building an AI application with inconsistent LLM outputs that need better structure and reliability",
+        "Developer implementing a complex reasoning task requiring step-by-step analysis across multiple domains",
+        "Engineering team optimizing LLM costs while maintaining output quality across a production application"
+      ],
       "domains": [
         "ai-infrastructure",
         "machine-learning"
@@ -667,7 +691,7 @@
         "typescript"
       ],
       "capabilities": [
-        "'<example>",
+        "'example",
         "1. **Rehost (Lift-and-Shift)** - Fastest path, minimal changes, move to IaaS (EC2/Azure VMs)",
         "- Minor optimizations, use managed databases (RDS/Azure SQL)",
         "- Decompose into microservices, adopt serverless/containers",
@@ -706,9 +730,9 @@
         "testing"
       ],
       "capabilities": [
-        "**Human Oversight**: Human oversight measures including override capability, system monitoring by qualified personnel, intervention procedures. Evidence: Oversight procedures, training records, override logs.",
-        "**Accuracy, Robustness, Cybersecurity**: Performance testing results, resilience to errors and adversarial attacks, cybersecurity measures throughout lifecycle. Evidence: Testing reports, penetration test results, security assessment.",
-        "**Quality Management System**: Quality assurance processes, post-market monitoring, incident reporting procedures, continuous improvement. Evidence: QMS documentation, monitoring reports, incident logs."
+        "Organization preparing for SOC 2 Type II audit with 6-month evidence collection period",
+        "Software organization with multiple compliance requirements across frameworks",
+        "Development team implementing high-risk AI system under EU AI Act"
       ],
       "domains": [
         "software-architecture",
@@ -733,7 +757,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team needs monthly SDLC compliance status with actionable remediation items",
+        "Executive leadership requires quarterly compliance dashboard showing progress toward SOC 2 readiness",
+        "Audit team needs evidence package documenting SDLC process compliance over the last 6 months"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -799,8 +827,9 @@
         "testing"
       ],
       "capabilities": [
-        "context: Team refactored a data processing pipeline to improve performance but needs to verify it still meets original functional requirements",
-        "context: Proactive review after completing a significant API implementation to catch deviations early before they compound"
+        "Team has just completed implementing a new authentication module with OAuth2 and multi-factor authentication capabilities",
+        "Team refactored a data processing pipeline to improve performance but needs to verify it still meets original functional requirements",
+        "Proactive review after completing a significant API implementation to catch deviations early before they compound"
       ],
       "domains": [
         "software-architecture",
@@ -848,7 +877,13 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team designing a new user analytics system that will collect behavioral data across multiple regions including EU, California, and Brazil",
+        "Application receives a GDPR data subject access request (DSAR) from a user requesting all their personal data",
+        "Engineering team about to start building a new feature that will process user location data for personalized recommendations",
+        "Startup expanding from US-only operations to serve European customers, needs to understand GDPR compliance requirements",
+        "Security team implementing encryption for user data and needs guidance on privacy-specific encryption requirements"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -886,11 +921,9 @@
         "testing"
       ],
       "capabilities": [
-        "**Use fully managed database** because operational overhead is significant",
-        "Managed services handle: Backups, patching, HA configuration, monitoring, scaling",
-        "Cost trade-off: Higher per-unit cost, but lower total cost when including operational labor",
-        "Example: RDS vs EC2 self-managed (RDS 30% more expensive, but saves 20+ hours/month ops work)",
-        "- **Use serverless database (Aurora Serverless, Neon)** because it automatically scales and optimizes costs"
+        "Team designing database schema for new e-commerce platform with complex product catalog and high transaction volume",
+        "Production application experiencing slow query performance and connection pool exhaustion during peak traffic",
+        "Enterprise planning migration from Oracle to PostgreSQL to reduce licensing costs while maintaining high availability"
       ],
       "domains": [
         "software-architecture",
@@ -921,7 +954,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Building a new specialist agent that requires current domain knowledge",
+        "Gathering current best practices and tooling for an existing agent refresh",
+        "Investigating a new domain where no agent exists yet"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -962,7 +999,11 @@
         "testing",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team needs to design a CI/CD pipeline with zero-trust security and SLSA compliance",
+        "Organization adopting GitOps for Kubernetes deployments across multiple environments",
+        "Platform team building an internal developer platform to reduce cognitive load"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -981,7 +1022,11 @@
         "security",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team with 5+ developers consistently skipping architecture documentation despite multiple warnings from sdlc-enforcer",
+        "Organization rolling out Zero Technical Debt policy to 15 teams with varying maturity levels",
+        "Senior team resisting retrospective requirements, claiming they already do informal post-mortems"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1003,8 +1048,8 @@
         "testing"
       ],
       "capabilities": [
-        "'<example>",
-        "You are a Senior Security Architect with 20+ years of experience designing secure systems for financial services, healthcare, and government sectors. You have CISSP, CCSP, and CEH certifications, and you've led security architecture for systems processing billions of transactions daily. You combine deep technical security expertise with practical business understanding to create robust, compliant, and usable security solutions.",
+        "'example",
+        "You are a Senior Security Architect with 20+ years of experience designing secure systems for financ...",
         "Threat modeling using STRIDE, PASTA, and DREAD methodologies",
         "Security design patterns and architecture principles",
         "Cryptographic implementation and key management"
@@ -1046,7 +1091,7 @@
         "vue"
       ],
       "capabilities": [
-        "'<example>"
+        "'example"
       ],
       "domains": [
         "software-architecture",
@@ -1081,7 +1126,10 @@
         "typescript",
         "vue"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building a React SPA with user-generated content and third-party integrations",
+        "Implementing OAuth 2.0 authentication in a Vue.js application"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1117,7 +1165,11 @@
         "security",
         "test"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team setting up a new repository for a microservices project with security scanning requirements",
+        "Organization wants to optimize GitHub Actions usage and reduce runner costs",
+        "Engineering team needs to automate PR workflows and code review processes"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1153,11 +1205,9 @@
         "typescript"
       ],
       "capabilities": [
-        "App size and startup time are critical metrics",
-        "- Team has strong JavaScript/TypeScript skills",
-        "Need to share code with React web app",
-        "Rapid prototyping and iteration are priorities",
-        "Large ecosystem of third-party libraries is valuable"
+        "Team deciding between native and cross-platform development for a new mobile app",
+        "Designing mobile app architecture for offline-first experience",
+        "Setting up mobile CI/CD pipeline for automated builds and distribution"
       ],
       "domains": [
         "software-architecture",
@@ -1216,7 +1266,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Creating a new agent from web research",
+        "Creating an agent from an internal repository",
+        "Determining the right research approach"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1249,11 +1303,9 @@
         "testing"
       ],
       "capabilities": [
-        "**Extract decision records**: Look for ADR (Architecture Decision Records) or similar documents",
-        "**Extract architectural diagrams**: Find Mermaid, PlantUML, ASCII diagrams and describe their content",
-        "**Extract integration specs**: API contracts, message formats, protocol specifications",
-        "**Extract design patterns**: Documented approaches to common problems",
-        "**Extract environment structures**: Development, staging, production environment definitions"
+        "Creating an agent from an internal methodology repository",
+        "Extracting knowledge from a documentation-heavy repository",
+        "Discovering portable skills and configurations from a Claude Code project"
       ],
       "domains": [
         "software-architecture",
@@ -1314,7 +1366,11 @@
         "test",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Starting any new feature or work in an AI-First SDLC project",
+        "Checking if project setup meets AI-First SDLC standards",
+        "Developer attempting to push directly to main branch"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1353,7 +1409,7 @@
         "testing"
       ],
       "capabilities": [
-        "'<example>"
+        "'example"
       ],
       "domains": [
         "software-architecture",
@@ -1397,7 +1453,9 @@
         "typescript"
       ],
       "capabilities": [
-        "You are the Solution Architect, the strategic design authority responsible for end-to-end system architecture spanning frontend, backend, data, infrastructure, and integration layers. You translate business requirements into comprehensive technical solutions, evaluate architectural trade-offs using established frameworks (TOGAF, C4, ATAM), and ensure systems are designed for scalability, resilience, and evolvability. Your approach is methodical and framework-driven, grounding every architectural decision in documented rationale and explicit trade-off analysis."
+        "Team designing a new microservices platform that needs to scale from 100K to 10M users",
+        "Legacy system migration from on-premise monolith to cloud-native architecture",
+        "Technology stack selection for a new SaaS product with specific requirements"
       ],
       "domains": [
         "software-architecture",
@@ -1435,7 +1493,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team launching a new service requiring 99.95% availability SLA",
+        "Production incidents are frequent and chaotic with no clear response process",
+        "Organization wants to start chaos engineering practice"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1491,7 +1553,10 @@
         "typescript",
         "vue"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team designing a multi-brand enterprise design system with accessibility compliance requirements",
+        "Product team needs to improve dashboard usability based on user complaints about information overload"
+      ],
       "domains": [
         "software-architecture",
         "system-design"
@@ -1526,11 +1591,9 @@
         "vue"
       ],
       "capabilities": [
-        "- Static site generators: Docusaurus (React-based, Meta), MkDocs (Python, Material theme), Astro Starlight (Astro framework), VitePress (Vue-based, lightweight), Nextra (Next.js-based)",
-        "Documentation hosting: Vercel, Netlify, GitHub Pages, Read the Docs, Cloudflare Pages",
-        "Search engines: Algolia DocSearch, Meilisearch, Typesense, local Lunr.js, OpenSearch",
-        "Versioning strategies: Git-based, documentation versions aligned with software versions, legacy version archiving",
-        "- Git workflow for documentation (branch strategies, review processes, merge requirements)"
+        "Team launching a new developer platform with APIs, SDKs, and multiple client types requiring comprehensive documentation",
+        "Organization with fragmented documentation across wikis, PDFs, GitHub READMEs, and Confluence with no clear ownership or versioning",
+        "Engineering team adopting API-first development and needing automated API documentation generation integrated into CI/CD"
       ],
       "domains": [
         "technical-writing",
@@ -1564,7 +1627,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team needs API documentation that developers can follow under deadline pressure",
+        "Existing documentation generates excessive support tickets due to unclear instructions",
+        "Tutorial needs to teach a complex distributed systems concept to backend developers"
+      ],
       "domains": [
         "technical-writing",
         "knowledge-management"
@@ -1590,11 +1657,9 @@
         "testing"
       ],
       "capabilities": [
-        "**Round-Robin**: Simple, fair distribution, no state required, poor for heterogeneous servers",
-        "**Least Connections**: Route to server with fewest active connections, better for varying request complexity",
-        "**Capability-Based**: Route requests to servers advertising required tools, ensures request satisfaction",
-        "**Affinity Routing**: Sticky sessions for stateful workflows, session continuity, complicates load distribution",
-        "**Weighted Routing**: Proportional to server capacity/performance, accommodates heterogeneous fleet"
+        "Team needs to coordinate multiple MCP servers across a distributed system with different tool providers",
+        "Organization deploying MCP infrastructure at enterprise scale with multi-tenant requirements",
+        "AI agent workflow spans multiple MCP servers requiring coordinated tool execution"
       ],
       "domains": [
         "protocol-implementation"
@@ -1613,8 +1678,8 @@
         "testing"
       ],
       "capabilities": [
-        "**Pythonic Improvements**: Specific suggestions to make code more idiomatic with before/after examples",
-        "**Performance Analysis**: Identified bottlenecks with profiling recommendations and optimization strategies",
+        "**Pythonic Improvements**: Specific suggestions to make code more idiomatic with before/after exampl...",
+        "**Performance Analysis**: Identified bottlenecks with profiling recommendations and optimization str...",
         "**Type Safety Enhancements**: Missing or incorrect type hints with complete typing solutions",
         "**PEP Compliance Issues**: Style violations with automated tool recommendations (black, ruff, mypy)",
         "**Security Considerations**: Potential vulnerabilities with secure coding alternatives"
@@ -1638,7 +1703,9 @@
         "testing"
       ],
       "capabilities": [
-        "You are the Agile Coach, the specialist responsible for guiding teams through agile adoption, diagnosing process dysfunctions, and building sustainable delivery practices. You coach teams from initial Scrum adoption through scaled agile transformation, combining deep knowledge of agile frameworks (Scrum, Kanban, SAFe, LeSS) with practical experience in team dynamics, metrics implementation, and continuous improvement. Your approach is diagnostic and contextual -- you assess team maturity and organizational constraints before recommending practices, never imposing rigid frameworks on teams with unique contexts."
+        "Development team struggling with missed sprint commitments, inconsistent velocity, and low morale after three months of Scrum adoption",
+        "Organization with 8 development teams needs to coordinate dependencies and align on quarterly objectives while maintaining team autonomy",
+        "Engineering team using AI coding assistants (GitHub Copilot) experiencing confusion about velocity tracking and estimation accuracy"
       ],
       "domains": [
         "delivery",
@@ -1670,7 +1737,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Multi-team enterprise project approaching critical release with 12 integration dependencies across 4 teams, delivery date in 3 weeks",
+        "Team experiencing frequent production incidents and missed delivery commitments, stakeholders losing confidence",
+        "Executive leadership needs visibility into delivery risks and timeline confidence for quarterly planning"
+      ],
       "domains": [
         "delivery",
         "coordination"
@@ -1692,7 +1763,12 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team has completed the authentication module and needs to verify progress against the implementation plan",
+        "Product manager needs to know if all planned MVP deliverables are complete before the release",
+        "Project is experiencing delays on API integration and the team needs to assess impact",
+        "Weekly status meeting requires current project health assessment"
+      ],
       "domains": [
         "delivery",
         "coordination"
@@ -1716,7 +1792,11 @@
         "sql",
         "test"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Engineering manager wants to understand team delivery capability",
+        "DevOps lead tracking infrastructure-as-code adoption across teams",
+        "Director concerned about team morale declining"
+      ],
       "domains": [
         "delivery",
         "coordination"
@@ -1814,7 +1894,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building a new Go microservice with gRPC and needs proper project structure",
+        "Go service experiencing memory pressure and goroutine leaks under load",
+        "Team needs to choose between Go frameworks and ORMs for a new project"
+      ],
       "domains": [
         "process-improvement",
         "methodology"
@@ -1849,7 +1933,12 @@
         "typescript",
         "vue"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team starting a new TypeScript project and needs to choose the right tooling stack",
+        "React application has performance issues with slow initial load and large bundle size",
+        "Node.js backend needs to choose between Express, Fastify, and newer frameworks",
+        "Team wants to add TypeScript to an existing JavaScript codebase incrementally"
+      ],
       "domains": [
         "process-improvement",
         "methodology"
@@ -1890,8 +1979,9 @@
         "typescript"
       ],
       "capabilities": [
-        "Provide Python-specific implementation for architectures designed by solution-architect or backend-architect",
-        "When Python patterns conflict with AI-First SDLC requirements, find Python solutions that satisfy both (don't compromise on either)"
+        "Team building a FastAPI microservice with async operations and needs strict type safety for AI-First SDLC compliance",
+        "Django project needs migration to typed Python with comprehensive testing while maintaining backward compatibility",
+        "AI/ML team needs Python data pipeline with production-grade quality and performance optimization"
       ],
       "domains": [
         "process-improvement",
@@ -1963,11 +2053,10 @@
         "testing"
       ],
       "capabilities": [
-        "**Problem**: Specific challenge the pattern addresses. Example: \"Need CI/CD but can't invest 2 weeks in pipeline setup\"",
-        "**Solution**: Step-by-step implementation with decision points. Example: \"Use GitHub Actions with templates from examples/ci-cd/, customize in 2 hours\"",
-        "**Consequences**: Benefits, trade-offs, limitations, maintenance burden. Example: \"Fast setup but less flexibility than Jenkins, adequate for <10 engineers\"",
-        "**By Maturity**: Experimental (< 5 teams, < 3 months), Validated (5-20 teams, 3-12 months), Proven (20+ teams, 12+ months, documented success metrics)",
-        "**By Complexity**: Simple (1-2 hour implementation, single developer), Moderate (1-3 days, team coordination), Complex (1+ weeks, cross-team dependencies)"
+        "Team struggling with repeated architecture documentation violations",
+        "New JavaScript team joining the AI-First SDLC framework",
+        "Engineering manager wants to measure AI-First adoption effectiveness",
+        "Team discovering a new anti-pattern in their workflow"
       ],
       "domains": [
         "process-improvement",
@@ -1992,66 +2081,12 @@
         "python",
         "test"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Delegated by V3 orchestrator to set up GitHub",
+        "Ensuring local and remote alignment"
+      ],
       "domains": [],
       "description": "Handles GitHub configuration, local setup, and alignment between local and remote SDLC environments"
-    },
-    {
-      "name": "project-strategy-orchestrator",
-      "path": "agents/templates/project-strategy-orchestrator.md",
-      "category": "templates",
-      "keywords": [
-        "ai",
-        "angular",
-        "api",
-        "architecture",
-        "cd",
-        "ci",
-        "database",
-        "devops",
-        "docker",
-        "frontend",
-        "go",
-        "javascript",
-        "k8s",
-        "kubernetes",
-        "ml",
-        "mongodb",
-        "postgres",
-        "python",
-        "quality",
-        "react",
-        "security",
-        "test",
-        "testing",
-        "typescript",
-        "vue"
-      ],
-      "capabilities": [],
-      "domains": [],
-      "description": "Autonomous project analyzer and strategic setup decision maker"
-    },
-    {
-      "name": "team-assembly-orchestrator",
-      "path": "agents/templates/team-assembly-orchestrator.md",
-      "category": "templates",
-      "keywords": [
-        "api",
-        "architecture",
-        "database",
-        "design",
-        "devops",
-        "frontend",
-        "python",
-        "quality",
-        "react",
-        "security",
-        "test",
-        "testing"
-      ],
-      "capabilities": [],
-      "domains": [],
-      "description": "Assembles and coordinates specialized agent teams based on project needs"
     },
     {
       "name": "ai-test-engineer",
@@ -2092,7 +2127,11 @@
         "typescript",
         "vue"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team migrating to microservices architecture and needs a testing strategy that ensures service reliability and contract compatibility",
+        "Development team experiencing frequent CI pipeline failures due to unreliable tests that pass locally but fail in CI",
+        "Organization wants to accelerate testing without sacrificing coverage, exploring AI-assisted test generation"
+      ],
       "domains": [
         "quality-assurance",
         "test-automation"
@@ -2127,7 +2166,11 @@
         "testing",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team has a PR touching authentication logic that needs security-focused review",
+        "Developer wants to set up automated code review for a Python/TypeScript project",
+        "Code changes in a PR include database migrations and need design review"
+      ],
       "domains": [
         "quality-assurance",
         "test-automation"
@@ -2166,7 +2209,11 @@
         "testing",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Team building microservices architecture with multiple service dependencies and needs comprehensive integration testing strategy",
+        "Frontend and backend teams experiencing frequent integration issues after deployments despite passing unit tests",
+        "Team needs to test complex user journeys across multiple services but E2E tests are flaky and slow"
+      ],
       "domains": [
         "quality-assurance",
         "test-automation"
@@ -2206,7 +2253,11 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Production API experiencing P95 latency above 500ms under normal load",
+        "Planning for Black Friday traffic expecting 10x normal load",
+        "Setting up performance testing in CI/CD pipeline"
+      ],
       "domains": [
         "quality-assurance",
         "test-automation"
@@ -2245,7 +2296,11 @@
         "testing",
         "typescript"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "MCP project needing specialized agents",
+        "Ambiguous project requirements",
+        "Discovering existing agents instead of generating"
+      ],
       "domains": [
         "protocol-implementation"
       ],
@@ -2271,7 +2326,10 @@
         "test",
         "testing"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Starting fresh project setup",
+        "Customizing for specific project type"
+      ],
       "domains": [],
       "description": "Pure download orchestrator for AI-First SDLC v3 setup - NO agent creation allowed"
     },
@@ -2298,7 +2356,8 @@
         "testing"
       ],
       "capabilities": [
-        "- Recruit new team members (create via template ONLY)"
+        "Starting fresh project setup",
+        "Specialized need not covered"
       ],
       "domains": [],
       "description": "Team-first orchestrator - uses existing agents, creates only as last resort with template"
@@ -2338,7 +2397,10 @@
         "typescript",
         "vue"
       ],
-      "capabilities": [],
+      "capabilities": [
+        "Starting AI-First SDLC in an existing project",
+        "Team wants AI agents but needs guidance"
+      ],
       "domains": [],
       "description": "Orchestrates AI-First SDLC v3 setup by discovering project needs and assembling the right team"
     }

--- a/AGENT-INDEX.md
+++ b/AGENT-INDEX.md
@@ -1,6 +1,6 @@
 # Agent Catalog Index
-*Generated: 2026-02-24T21:10:29.829309*
-*Total Agents: 70*
+*Generated: 2026-02-25T14:52:03.180605*
+*Total Agents: 68*
 
 ## Agents by Category
 
@@ -11,31 +11,45 @@
 - **Description**: Expert in LLM serving infrastructure, GPU orchestration, AI cost optimization, and multi-agent system operations. Use for deploying AI systems to production, managing AI-specific CI/CD, and operating ...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, claude, cloud, container
 - **Key Capabilities**:
-  - context: AI infrastructure costs growing beyond budget without clear visibility
-  - You are the AI DevOps Engineer, the specialist responsible for deploying and operating AI systems in production. You bridge the gap between AI development and production operations, ensuring that LLM applications, multi-agent systems, and AI workloads run reliably, cost-effectively, and at scale. Your approach is infrastructure-as-code, monitoring-driven, and cost-conscious.
+  - Team deploying a customer-facing LLM API requiring sub-second response times and cost control
+  - Multi-agent orchestration system ready for production deployment with 10 specialized agents
+  - AI infrastructure costs growing beyond budget without clear visibility
 
 #### `ai-team-transformer`
 - **Path**: `agents/ai-builders/ai-team-transformer.md`
 - **Description**: Expert in AI team transformation, multi-agent orchestration, and developer coaching. Use for AI adoption programs, team collaboration training, and building legendary AI-augmented teams.
 - **Keywords**: ai, api, architecture, auth, database, design, devops, frontend, go, jwt
+- **Key Capabilities**:
+  - Team wants to adopt AI-first development practices
+  - Developer struggling with multi-agent coordination
+  - Organization measuring AI team effectiveness
 
 #### `context-engineer`
 - **Path**: `agents/ai-builders/context-engineer.md`
 - **Description**: Expert in AI memory architectures, context window optimization, token budget management, and state persistence. Use for designing conversation memory systems, implementing sliding window strategies, R...
 - **Keywords**: ai, api, architecture, aws, claude, cloud, database, design, gpt, graphql
+- **Key Capabilities**:
+  - Team building a customer service chatbot that needs to remember conversation history across multiple sessions
+  - AI application hitting token limits in long conversations
+  - Multi-agent system where agents need to share context
 
 #### `orchestration-architect`
 - **Path**: `agents/ai-builders/orchestration-architect.md`
 - **Description**: Expert in multi-agent workflow design, state machines, agent coordination, and distributed orchestration. Use for designing agent pipelines, implementing handoff protocols, scaling orchestration syste...
 - **Keywords**: ai, api, architecture, aws, azure, cloud, design, devops, frontend, gpt
+- **Key Capabilities**:
+  - Team building document processing pipeline with multiple specialized agents for extraction, validation, and transformation
+  - Production system where agents occasionally give conflicting responses and coordination is unclear
+  - Engineering team evaluating orchestration frameworks for new AI-powered customer support system
 
 #### `rag-system-designer`
 - **Path**: `agents/ai-builders/rag-system-designer.md`
 - **Description**: RAG architecture specialist for vector databases, embeddings, chunking strategies, and retrieval optimization. Use for designing production RAG systems, selecting vector stores, or optimizing retrieva...
 - **Keywords**: ai, api, architecture, cloud, database, design, devops, frontend, jwt, llm
 - **Key Capabilities**:
-  - including index algorithms (HNSW, IVF, ScaNN), distance metrics (cosine, dot product, euclidean), and sharding strategies for scale
-  - with understanding of dimensionality, language support, domain fine-tuning, and latency/cost trade-offs
+  - Team building a technical documentation search system with 50K+ pages
+  - Existing RAG system returning irrelevant results despite semantic search
+  - RAG system experiencing high latency and embedding costs at scale
 
 ### Ai Development (9 agents)
 
@@ -43,20 +57,28 @@
 - **Path**: `agents/ai-development/a2a-architect.md`
 - **Description**: Expert in multi-agent system architecture including MCP and A2A protocols, inter-agent messaging, orchestration patterns, fault tolerance, and scaling strategies. Use for designing agent communication...
 - **Keywords**: ai, api, architecture, auth, cloud, container, database, design, devops, go
+- **Key Capabilities**:
+  - Team designing multi-agent research system with LangChain and AutoGen agents
+  - Team implementing agent orchestration with supervisor coordinating 50 workers
+  - Production multi-agent system experiencing cascading failures
 
 #### `agent-developer`
 - **Path**: `agents/ai-development/agent-developer.md`
 - **Description**: Expert in agent architecture, persona design, and multi-agent systems. Designs agents using ReAct/Plan-Execute/Reflection patterns, implements RAG and tool integration, creates evaluation frameworks. ...
 - **Keywords**: ai, api, architecture, aws, cloud, database, design, gpt, jwt, llm
 - **Key Capabilities**:
-  - context: Existing agent producing inconsistent results in production
-  - context: Building a multi-agent system with coordination challenges
-  - You are the Agent Developer, an expert in designing and building AI agent systems using modern LLM architectures. You design agent reasoning patterns (ReAct, Plan-and-Execute, Reflection), craft effective personas using the Professional Specialist Pattern, architect multi-agent coordination systems, and implement production-ready guardrails and evaluation frameworks. Your approach is research-grounded—every architectural decision traces to established patterns from LangGraph, AutoGen, CrewAI, and production agent systems, and you balance theoretical best practices with practical deployment constraints.
+  - Team needs to design a new specialized agent for their domain
+  - Existing agent producing inconsistent results in production
+  - Building a multi-agent system with coordination challenges
 
 #### `ai-solution-architect`
 - **Path**: `agents/ai-development/ai-solution-architect.md`
 - **Description**: Expert in AI/ML system architecture, LLM application design, RAG systems, MLOps pipelines, and AI safety. Use for designing AI systems, evaluating model selection, architecting multi-agent systems, an...
 - **Keywords**: ai, api, architecture, auth, aws, azure, claude, cloud, container, database
+- **Key Capabilities**:
+  - Team designing a new customer service AI system using LLMs and RAG
+  - Reviewing an existing AI system architecture for production readiness
+  - Designing MLOps infrastructure for a new AI initiative
 
 #### `junior-ai-solution-architect`
 - **Path**: `agents/ai-development/junior-ai-solution-architect.md`
@@ -68,37 +90,45 @@
 - **Description**: Expert in LangChain 0.1+ and LangGraph architectures. Use for LCEL chain design, RAG system architecture, multi-agent orchestration, tool integration patterns, or production deployment of LLM applicat...
 - **Keywords**: ai, api, architecture, aws, cd, ci, cloud, database, design, devops
 - **Key Capabilities**:
-  - Success criteria: Accuracy, speed, cost targets
-  - 1. Classify the problem type: RAG, agent, chain, multi-agent
-  - Requirements summary with LangChain component mapping
+  - Team building a RAG system for enterprise document analysis with LangChain
+  - Developer implementing complex agent workflow with multiple decision points
+  - After implementing a LangChain application experiencing high token costs
 
 #### `mcp-quality-assurance`
 - **Path**: `agents/ai-development/mcp-quality-assurance.md`
 - **Description**: Expert in MCP specification compliance, security auditing, and production readiness assessment. Use for quality reviews, security assessments, and deployment validation of MCP servers.
 - **Keywords**: ai, api, architecture, cd, ci, container, database, design, devops, go
 - **Key Capabilities**:
-  - Current stable version requirements and feature sets
-  - Beta feature implementation guidance with stability caveats
-  - Deprecation timeline awareness for sunset features
+  - Team finishing MCP server implementation before production deployment
+  - Development team concerned about security in their database MCP tools
+  - Team wants to validate MCP specification compliance before release
 
 #### `mcp-server-architect`
 - **Path**: `agents/ai-development/mcp-server-architect.md`
 - **Description**: Expert in Model Context Protocol server architecture, tool schema design, transport configuration, and production deployment. Use for MCP server design, tool hierarchy planning, security architecture,...
 - **Keywords**: ai, api, architecture, auth, aws, azure, claude, container, database, design
 - **Key Capabilities**:
-  - MCP specification version tracking and capability negotiation patterns
-  - Transport mechanisms: stdio (local processes), SSE (server-sent events for web), HTTP with long-polling
-  - Protocol primitives: tools (AI-invocable functions), resources (context data with URIs), prompts (reusable templates), sampling (LLM completion requests)
+  - Team building an MCP server to expose database operations to Claude Desktop
+  - Existing MCP server experiencing performance issues with resource enumeration
+  - Deploying MCP server to production with multiple AI clients
 
 #### `mcp-test-agent`
 - **Path**: `agents/ai-development/mcp-test-agent.md`
 - **Description**: MCP server testing specialist validating functionality, reliability, performance, and AI usability. Use for testing MCP implementations, validating production readiness, or debugging server issues.
 - **Keywords**: ai, api, architecture, cd, ci, database, design, javascript, mcp, model context protocol
+- **Key Capabilities**:
+  - Team has built an MCP server exposing database tools and needs comprehensive validation before deployment
+  - Developer is debugging why their MCP server works inconsistently and needs root cause analysis
+  - Team needs to validate error handling before releasing MCP server to external AI clients
 
 #### `prompt-engineer`
 - **Path**: `agents/ai-development/prompt-engineer.md`
 - **Description**: Expert in prompt engineering for Claude, GPT, Gemini, and Llama models. Specializes in chain-of-thought prompting, structured outputs, few-shot learning, system prompt architecture, and prompt optimiz...
 - **Keywords**: ai, api, architecture, claude, cloud, database, design, devops, frontend, go
+- **Key Capabilities**:
+  - Team building an AI application with inconsistent LLM outputs that need better structure and reliability
+  - Developer implementing a complex reasoning task requiring step-by-step analysis across multiple domains
+  - Engineering team optimizing LLM costs while maintaining output quality across a production application
 
 ### Core (29 agents)
 
@@ -122,7 +152,7 @@
 - **Description**: Expert in multi-cloud strategy, service selection, IaC patterns, cost optimization, and cloud-native architecture across AWS, Azure, and GCP with focus on serverless, managed services, and well-archit...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, claude, cloud, container
 - **Key Capabilities**:
-  - '<example>
+  - 'example
   - 1. **Rehost (Lift-and-Shift)** - Fastest path, minimal changes, move to IaaS (EC2/Azure VMs)
   - - Minor optimizations, use managed databases (RDS/Azure SQL)
 
@@ -131,14 +161,18 @@
 - **Description**: Comprehensive compliance auditing for SOC 2, ISO 27001, PCI DSS, GDPR, AI regulations, and security standards. Use for pre-audit assessments, gap analysis, evidence validation, and multi-framework com...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, design
 - **Key Capabilities**:
-  - **Human Oversight**: Human oversight measures including override capability, system monitoring by qualified personnel, intervention procedures. Evidence: Oversight procedures, training records, override logs.
-  - **Accuracy, Robustness, Cybersecurity**: Performance testing results, resilience to errors and adversarial attacks, cybersecurity measures throughout lifecycle. Evidence: Testing reports, penetration test results, security assessment.
-  - **Quality Management System**: Quality assurance processes, post-market monitoring, incident reporting procedures, continuous improvement. Evidence: QMS documentation, monitoring reports, incident logs.
+  - Organization preparing for SOC 2 Type II audit with 6-month evidence collection period
+  - Software organization with multiple compliance requirements across frameworks
+  - Development team implementing high-risk AI system under EU AI Act
 
 #### `compliance-report-generator`
 - **Path**: `agents/core/compliance-report-generator.md`
 - **Description**: Expert in SDLC compliance reporting, metrics visualization, remediation tracking, and audit-ready documentation. Use for creating actionable reports tailored to different audiences (team, executive, a...
 - **Keywords**: api, architecture, cd, ci, design, devops, pipeline, quality, security, test
+- **Key Capabilities**:
+  - Team needs monthly SDLC compliance status with actionable remediation items
+  - Executive leadership requires quarterly compliance dashboard showing progress toward SOC 2 readiness
+  - Audit team needs evidence package documenting SDLC process compliance over the last 6 months
 
 #### `container-platform-specialist`
 - **Path**: `agents/core/container-platform-specialist.md`
@@ -150,8 +184,9 @@
 - **Description**: Expert in requirements verification, goal alignment validation, and gap analysis for completed work. Use after implementing features, completing code sections, or finishing design work to ensure align...
 - **Keywords**: api, architecture, auth, database, design, devops, frontend, jwt, pipeline, quality
 - **Key Capabilities**:
-  - context: Team refactored a data processing pipeline to improve performance but needs to verify it still meets original functional requirements
-  - context: Proactive review after completing a significant API implementation to catch deviations early before they compound
+  - Team has just completed implementing a new authentication module with OAuth2 and multi-factor authentication capabilities
+  - Team refactored a data processing pipeline to improve performance but needs to verify it still meets original functional requirements
+  - Proactive review after completing a significant API implementation to catch deviations early before they compound
 
 #### `data-architect`
 - **Path**: `agents/core/data-architect.md`
@@ -165,56 +200,79 @@
 - **Path**: `agents/core/data-privacy-officer.md`
 - **Description**: Expert in GDPR, CCPA/CPRA, LGPD, PIPL, and privacy-by-design. Use for privacy impact assessments, data subject rights implementation, consent management, data minimization strategies, and multi-jurisd...
 - **Keywords**: ai, api, architecture, cloud, database, design, devops, go, microservice, ml
+- **Key Capabilities**:
+  - Team designing a new user analytics system that will collect behavioral data across multiple regions including EU, California, and Brazil
+  - Application receives a GDPR data subject access request (DSAR) from a user requesting all their personal data
+  - Engineering team about to start building a new feature that will process user location data for personalized recommendations
 
 #### `database-architect`
 - **Path**: `agents/core/database-architect.md`
 - **Description**: Expert in database design, schema modeling, query optimization, HA/DR architecture, and data security. Use for database technology selection, performance tuning, migration planning, and compliance imp...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, database
 - **Key Capabilities**:
-  - **Use fully managed database** because operational overhead is significant
-  - Managed services handle: Backups, patching, HA configuration, monitoring, scaling
-  - Cost trade-off: Higher per-unit cost, but lower total cost when including operational labor
+  - Team designing database schema for new e-commerce platform with complex product catalog and high transaction volume
+  - Production application experiencing slow query performance and connection pool exhaustion during peak traffic
+  - Enterprise planning migration from Oracle to PostgreSQL to reduce licensing costs while maintaining high availability
 
 #### `deep-research-agent`
 - **Path**: `agents/core/deep-research-agent.md`
 - **Description**: Executes systematic web research campaigns from structured prompts, evaluates sources via CRAAP, and produces synthesis documents.
 - **Keywords**: ai, api, architecture, aws, cloud, database, design, devops, docker, frontend
+- **Key Capabilities**:
+  - Building a new specialist agent that requires current domain knowledge
+  - Gathering current best practices and tooling for an existing agent refresh
+  - Investigating a new domain where no agent exists yet
 
 #### `devops-specialist`
 - **Path**: `agents/core/devops-specialist.md`
 - **Description**: Expert in CI/CD pipeline design, GitOps deployment strategies, infrastructure as code, container orchestration, and platform engineering. Use for designing deployment automation, implementing progress...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, database
+- **Key Capabilities**:
+  - Team needs to design a CI/CD pipeline with zero-trust security and SLSA compliance
+  - Organization adopting GitOps for Kubernetes deployments across multiple environments
+  - Platform team building an internal developer platform to reduce cognitive load
 
 #### `enforcement-strategy-advisor`
 - **Path**: `agents/core/enforcement-strategy-advisor.md`
 - **Description**: Expert in behavioral change psychology for software teams, enforcement strategy design, and SDLC adoption coaching. Use for designing enforcement approaches, managing resistance to standards, adapting...
 - **Keywords**: api, architecture, design, quality, security, testing
+- **Key Capabilities**:
+  - Team with 5+ developers consistently skipping architecture documentation despite multiple warnings from sdlc-enforcer
+  - Organization rolling out Zero Technical Debt policy to 15 teams with varying maturity levels
+  - Senior team resisting retrospective requirements, claiming they already do informal post-mortems
 
 #### `frontend-architect`
 - **Path**: `agents/core/frontend-architect.md`
 - **Description**: Expert in modern frontend architecture, component design patterns, state management strategies, performance optimization, accessibility standards, and SSR/SSG implementations. Use for architectural de...
 - **Keywords**: angular, api, architecture, auth, ci, container, database, design, devops, frontend
 - **Key Capabilities**:
-  - '<example>
+  - 'example
 
 #### `frontend-security-specialist`
 - **Path**: `agents/core/frontend-security-specialist.md`
 - **Description**: Expert in XSS prevention, CSP, OAuth/OIDC, SRI, and frontend threat modeling. Use for securing SPAs, implementing auth flows, and reviewing client-side security.
 - **Keywords**: angular, api, architecture, auth, cd, ci, cloud, container, database, design
+- **Key Capabilities**:
+  - Team building a React SPA with user-generated content and third-party integrations
+  - Implementing OAuth 2.0 authentication in a Vue.js application
 
 #### `github-integration-specialist`
 - **Path**: `agents/core/github-integration-specialist.md`
 - **Description**: Expert in GitHub platform features, Actions workflows, Advanced Security, branch protection, PR automation, and organization governance. Use for GitHub repository configuration, CI/CD design, security...
 - **Keywords**: ai, api, architecture, auth, aws, azure, cd, ci, cloud, design
+- **Key Capabilities**:
+  - Team setting up a new repository for a microservices project with security scanning requirements
+  - Organization wants to optimize GitHub Actions usage and reduce runner costs
+  - Engineering team needs to automate PR workflows and code review processes
 
 #### `mobile-architect`
 - **Path**: `agents/core/mobile-architect.md`
 - **Description**: Expert in mobile app architecture (native iOS/Android, React Native, Flutter, KMP), cross-platform decisions, mobile performance optimization, mobile CI/CD, and platform-specific guidelines. Consult f...
 - **Keywords**: api, architecture, aws, cd, ci, cloud, database, design, devops, frontend
 - **Key Capabilities**:
-  - App size and startup time are critical metrics
-  - - Team has strong JavaScript/TypeScript skills
-  - Need to share code with React web app
+  - Team deciding between native and cross-platform development for a new mobile app
+  - Designing mobile app architecture for offline-first experience
+  - Setting up mobile CI/CD pipeline for automated builds and distribution
 
 #### `observability-specialist`
 - **Path**: `agents/core/observability-specialist.md`
@@ -225,15 +283,19 @@
 - **Path**: `agents/core/pipeline-orchestrator.md`
 - **Description**: Unified entry point for agent creation pipeline. Routes web research or repo analysis, then delegates to agent-builder for construction.
 - **Keywords**: api, claude, design, kubernetes, ml, pipeline, python, quality, rest, security
+- **Key Capabilities**:
+  - Creating a new agent from web research
+  - Creating an agent from an internal repository
+  - Determining the right research approach
 
 #### `repo-knowledge-distiller`
 - **Path**: `agents/core/repo-knowledge-distiller.md`
 - **Description**: Analyzes repositories and knowledge bases to produce synthesis documents for agent creation via RELIC evaluation and artifact discovery.
 - **Keywords**: api, architecture, auth, azure, cd, ci, claude, database, design, go
 - **Key Capabilities**:
-  - **Extract decision records**: Look for ADR (Architecture Decision Records) or similar documents
-  - **Extract architectural diagrams**: Find Mermaid, PlantUML, ASCII diagrams and describe their content
-  - **Extract integration specs**: API contracts, message formats, protocol specifications
+  - Creating an agent from an internal methodology repository
+  - Extracting knowledge from a documentation-heavy repository
+  - Discovering portable skills and configurations from a Claude Code project
 
 #### `sdlc-coach`
 - **Path**: `agents/core/sdlc-coach.md`
@@ -248,14 +310,18 @@
 - **Path**: `agents/core/sdlc-enforcer.md`
 - **Description**: Expert in AI-First SDLC compliance enforcement, progressive quality gates, Zero Technical Debt policy, and process validation. Use for real-time compliance checking during development, branch protecti...
 - **Keywords**: ai, api, architecture, auth, cd, ci, claude, database, design, go
+- **Key Capabilities**:
+  - Starting any new feature or work in an AI-First SDLC project
+  - Checking if project setup meets AI-First SDLC standards
+  - Developer attempting to push directly to main branch
 
 #### `security-architect`
 - **Path**: `agents/core/example-security-architect.md`
 - **Description**: Expert in security architecture, threat modeling, and secure design patterns. Reviews systems for vulnerabilities and recommends security improvements.
 - **Keywords**: api, architecture, design, jwt, security, sql, test, testing
 - **Key Capabilities**:
-  - '<example>
-  - You are a Senior Security Architect with 20+ years of experience designing secure systems for financial services, healthcare, and government sectors. You have CISSP, CCSP, and CEH certifications, and you've led security architecture for systems processing billions of transactions daily. You combine deep technical security expertise with practical business understanding to create robust, compliant, and usable security solutions.
+  - 'example
+  - You are a Senior Security Architect with 20+ years of experience designing secure systems for financ...
   - Threat modeling using STRIDE, PASTA, and DREAD methodologies
 
 #### `security-architect`
@@ -263,19 +329,25 @@
 - **Description**: Expert in security architecture design, threat modeling, zero-trust principles, and secure SDLC integration. Use for architectural security reviews, compliance framework guidance, threat modeling sess...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, database
 - **Key Capabilities**:
-  - '<example>
+  - 'example
 
 #### `solution-architect`
 - **Path**: `agents/core/solution-architect.md`
 - **Description**: Expert in system architecture design, TOGAF/C4 frameworks, distributed systems patterns, cloud-native architecture, and technology evaluation. Use for end-to-end solution design, migration strategies,...
 - **Keywords**: api, architecture, aws, azure, cd, ci, cloud, container, database, design
 - **Key Capabilities**:
-  - You are the Solution Architect, the strategic design authority responsible for end-to-end system architecture spanning frontend, backend, data, infrastructure, and integration layers. You translate business requirements into comprehensive technical solutions, evaluate architectural trade-offs using established frameworks (TOGAF, C4, ATAM), and ensure systems are designed for scalability, resilience, and evolvability. Your approach is methodical and framework-driven, grounding every architectural decision in documented rationale and explicit trade-off analysis.
+  - Team designing a new microservices platform that needs to scale from 100K to 10M users
+  - Legacy system migration from on-premise monolith to cloud-native architecture
+  - Technology stack selection for a new SaaS product with specific requirements
 
 #### `sre-specialist`
 - **Path**: `agents/core/sre-specialist.md`
 - **Description**: Expert in SLO frameworks, incident response, chaos engineering, production reliability, and operational excellence. Use for defining SLIs/SLOs/error budgets, designing incident runbooks, implementing ...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, database
+- **Key Capabilities**:
+  - Team launching a new service requiring 99.95% availability SLA
+  - Production incidents are frequent and chaotic with no clear response process
+  - Organization wants to start chaos engineering practice
 
 #### `test-manager`
 - **Path**: `agents/core/test-manager.md`
@@ -290,6 +362,9 @@
 - **Path**: `agents/core/ux-ui-architect.md`
 - **Description**: Expert in design systems, WCAG 2.2/3.0 accessibility, user research methods, and design-to-development handoff. Use for interface design, accessibility audits, and UX strategy.
 - **Keywords**: angular, api, architecture, cd, ci, design, frontend, go, qa, react
+- **Key Capabilities**:
+  - Team designing a multi-brand enterprise design system with accessibility compliance requirements
+  - Product team needs to improve dashboard usability based on user complaints about information overload
 
 ### Documentation (2 agents)
 
@@ -298,14 +373,18 @@
 - **Description**: Expert in documentation systems design, docs-as-code pipelines, API documentation platforms (OpenAPI/AsyncAPI), and developer experience optimization. Use for documentation strategy, platform selectio...
 - **Keywords**: ai, api, architecture, cd, ci, design, devops, frontend, go, javascript
 - **Key Capabilities**:
-  - - Static site generators: Docusaurus (React-based, Meta), MkDocs (Python, Material theme), Astro Starlight (Astro framework), VitePress (Vue-based, lightweight), Nextra (Next.js-based)
-  - Documentation hosting: Vercel, Netlify, GitHub Pages, Read the Docs, Cloudflare Pages
-  - Search engines: Algolia DocSearch, Meilisearch, Typesense, local Lunr.js, OpenSearch
+  - Team launching a new developer platform with APIs, SDKs, and multiple client types requiring comprehensive documentation
+  - Organization with fragmented documentation across wikis, PDFs, GitHub READMEs, and Confluence with no clear ownership or versioning
+  - Engineering team adopting API-first development and needing automated API documentation generation integrated into CI/CD
 
 #### `technical-writer`
 - **Path**: `agents/documentation/technical-writer.md`
 - **Description**: Expert in technical writing, developer documentation, API docs, plain language principles, accessibility-first writing, and content design. Use for creating tutorials, guides, references, error messag...
 - **Keywords**: ai, api, architecture, auth, cd, ci, database, design, docker, go
+- **Key Capabilities**:
+  - Team needs API documentation that developers can follow under deadline pressure
+  - Existing documentation generates excessive support tickets due to unclear instructions
+  - Tutorial needs to teach a complex distributed systems concept to backend developers
 
 ### Future (1 agents)
 
@@ -314,9 +393,9 @@
 - **Description**: Expert in MCP multi-server coordination, gateway patterns, fleet management, and enterprise MCP deployment. Use for orchestrating multiple MCP servers, designing MCP gateways, managing MCP server flee...
 - **Keywords**: ai, api, architecture, database, design, devops, jwt, mcp, model-context-protocol, security
 - **Key Capabilities**:
-  - **Round-Robin**: Simple, fair distribution, no state required, poor for heterogeneous servers
-  - **Least Connections**: Route to server with fewest active connections, better for varying request complexity
-  - **Capability-Based**: Route requests to servers advertising required tools, ensures request satisfaction
+  - Team needs to coordinate multiple MCP servers across a distributed system with different tool providers
+  - Organization deploying MCP infrastructure at enterprise scale with multi-tenant requirements
+  - AI agent workflow spans multiple MCP servers requiring coordinated tool execution
 
 ### General (5 agents)
 
@@ -324,28 +403,42 @@
 - **Path**: `agents/sdlc-setup-specialist.md`
 - **Description**: Handles GitHub configuration, local setup, and alignment between local and remote SDLC environments
 - **Keywords**: ai, api, architecture, azure, cd, ci, claude, javascript, pipeline, python
+- **Key Capabilities**:
+  - Delegated by V3 orchestrator to set up GitHub
+  - Ensuring local and remote alignment
 
 #### `v3-setup-orchestrator`
 - **Path**: `agents/v3-setup-orchestrator.md`
 - **Description**: Orchestrates AI-First SDLC v3 setup by discovering project needs and assembling the right team
 - **Keywords**: ai, angular, api, architecture, azure, cd, ci, claude, cloud, container
+- **Key Capabilities**:
+  - Starting AI-First SDLC in an existing project
+  - Team wants AI agents but needs guidance
 
 #### `v3-setup-orchestrator-enhanced`
 - **Path**: `agents/v3-setup-orchestrator-enhanced.md`
 - **Description**: Enhanced orchestrator with dynamic agent discovery using searchable catalog and interactive clarification
 - **Keywords**: ai, api, architecture, auth, claude, design, devops, frontend, go, graphql
+- **Key Capabilities**:
+  - MCP project needing specialized agents
+  - Ambiguous project requirements
+  - Discovering existing agents instead of generating
 
 #### `v3-setup-orchestrator-no-creation`
 - **Path**: `agents/v3-setup-orchestrator-no-creation.md`
 - **Description**: Pure download orchestrator for AI-First SDLC v3 setup - NO agent creation allowed
 - **Keywords**: ai, api, claude, database, devops, frontend, go, javascript, mcp, ml
+- **Key Capabilities**:
+  - Starting fresh project setup
+  - Customizing for specific project type
 
 #### `v3-setup-orchestrator-team-first`
 - **Path**: `agents/v3-setup-orchestrator-team-first.md`
 - **Description**: Team-first orchestrator - uses existing agents, creates only as last resort with template
 - **Keywords**: ai, api, architecture, claude, database, design, devops, frontend, go, javascript
 - **Key Capabilities**:
-  - - Recruit new team members (create via template ONLY)
+  - Starting fresh project setup
+  - Specialized need not covered
 
 ### Languages (1 agents)
 
@@ -354,8 +447,8 @@
 - **Description**: Python language expert specializing in Pythonic patterns, performance optimization, and modern Python features. Ensures code follows PEP standards and community best practices.
 - **Keywords**: design, python, quality, security, testing
 - **Key Capabilities**:
-  - **Pythonic Improvements**: Specific suggestions to make code more idiomatic with before/after examples
-  - **Performance Analysis**: Identified bottlenecks with profiling recommendations and optimization strategies
+  - **Pythonic Improvements**: Specific suggestions to make code more idiomatic with before/after exampl...
+  - **Performance Analysis**: Identified bottlenecks with profiling recommendations and optimization str...
   - **Type Safety Enhancements**: Missing or incorrect type hints with complete typing solutions
 
 ### Project Management (4 agents)
@@ -365,22 +458,36 @@
 - **Description**: Expert in Scrum, Kanban, SAFe, and scaled agile. Use for sprint planning, retrospectives, team dysfunction diagnosis, agile transformation coaching, and metrics implementation (DORA, SPACE, flow).
 - **Keywords**: ai, architecture, claude, design, devops, go, quality, security, testing
 - **Key Capabilities**:
-  - You are the Agile Coach, the specialist responsible for guiding teams through agile adoption, diagnosing process dysfunctions, and building sustainable delivery practices. You coach teams from initial Scrum adoption through scaled agile transformation, combining deep knowledge of agile frameworks (Scrum, Kanban, SAFe, LeSS) with practical experience in team dynamics, metrics implementation, and continuous improvement. Your approach is diagnostic and contextual -- you assess team maturity and organizational constraints before recommending practices, never imposing rigid frameworks on teams with unique contexts.
+  - Development team struggling with missed sprint commitments, inconsistent velocity, and low morale after three months of Scrum adoption
+  - Organization with 8 development teams needs to coordinate dependencies and align on quarterly objectives while maintaining team autonomy
+  - Engineering team using AI coding assistants (GitHub Copilot) experiencing confusion about velocity tracking and estimation accuracy
 
 #### `delivery-manager`
 - **Path**: `agents/project-management/delivery-manager.md`
 - **Description**: Expert in software delivery orchestration, release management, risk mitigation, and stakeholder communication. Use for release planning, go/no-go decisions, delivery forecasting, cross-team coordinati...
 - **Keywords**: ai, api, architecture, auth, cd, ci, database, design, devops, frontend
+- **Key Capabilities**:
+  - Multi-team enterprise project approaching critical release with 12 integration dependencies across 4 teams, delivery date in 3 weeks
+  - Team experiencing frequent production incidents and missed delivery commitments, stakeholders losing confidence
+  - Executive leadership needs visibility into delivery risks and timeline confidence for quarterly planning
 
 #### `project-plan-tracker`
 - **Path**: `agents/project-management/project-plan-tracker.md`
 - **Description**: Use for monitoring project progress against established plans, tracking deliverables and milestones, detecting schedule slippage, analyzing dependencies, and generating status reports. Excels at early...
 - **Keywords**: api, architecture, cd, ci, design, pipeline, quality, test, testing
+- **Key Capabilities**:
+  - Team has completed the authentication module and needs to verify progress against the implementation plan
+  - Product manager needs to know if all planned MVP deliverables are complete before the release
+  - Project is experiencing delays on API integration and the team needs to assess impact
 
 #### `team-progress-tracker`
 - **Path**: `agents/project-management/team-progress-tracker.md`
 - **Description**: Expert in team performance measurement, adoption tracking, and health assessment. Use for tracking DORA metrics, measuring practice adoption, assessing team readiness, or generating team health report...
 - **Keywords**: api, architecture, cd, ci, design, devops, pipeline, quality, security, sql
+- **Key Capabilities**:
+  - Engineering manager wants to understand team delivery capability
+  - DevOps lead tracking infrastructure-as-code adoption across teams
+  - Director concerned about team morale declining
 
 ### Sdlc (8 agents)
 
@@ -402,19 +509,28 @@
 - **Path**: `agents/sdlc/language-go-expert.md`
 - **Description**: Expert in Go 1.22+ development, concurrency patterns, and cloud-native architectures. Use for Go project structure, performance optimization, and idiomatic Go practices.
 - **Keywords**: ai, api, architecture, cd, ci, cloud, container, database, design, devops
+- **Key Capabilities**:
+  - Team building a new Go microservice with gRPC and needs proper project structure
+  - Go service experiencing memory pressure and goroutine leaks under load
+  - Team needs to choose between Go frameworks and ORMs for a new project
 
 #### `language-javascript-expert`
 - **Path**: `agents/sdlc/language-javascript-expert.md`
 - **Description**: Expert in modern JavaScript/TypeScript, frontend/backend frameworks, build tooling, and JS ecosystem best practices. Use for framework selection, TypeScript config, bundle optimization, and Node.js de...
 - **Keywords**: angular, api, architecture, aws, cd, ci, database, design, devops, docker
+- **Key Capabilities**:
+  - Team starting a new TypeScript project and needs to choose the right tooling stack
+  - React application has performance issues with slow initial load and large bundle size
+  - Node.js backend needs to choose between Express, Fastify, and newer frameworks
 
 #### `language-python-expert`
 - **Path**: `agents/sdlc/language-python-expert.md`
 - **Description**: Expert in Python 3.12+ features, type systems (mypy/pyright), async patterns, testing (pytest/hypothesis), web frameworks (FastAPI/Django/Flask), AI/ML development, and packaging. Use for Python proje...
 - **Keywords**: ai, api, architecture, auth, aws, cd, ci, cloud, container, database
 - **Key Capabilities**:
-  - Provide Python-specific implementation for architectures designed by solution-architect or backend-architect
-  - When Python patterns conflict with AI-First SDLC requirements, find Python solutions that satisfy both (don't compromise on either)
+  - Team building a FastAPI microservice with async operations and needs strict type safety for AI-First SDLC compliance
+  - Django project needs migration to typed Python with comprehensive testing while maintaining backward compatibility
+  - AI/ML team needs Python data pipeline with production-grade quality and performance optimization
 
 #### `project-bootstrapper`
 - **Path**: `agents/sdlc/project-bootstrapper.md`
@@ -435,21 +551,9 @@
 - **Description**: Expert in SDLC knowledge management, pattern libraries, and learning extraction. Use for pattern discovery, onboarding guidance, success metrics, and maintaining institutional memory of what works.
 - **Keywords**: ai, architecture, cd, ci, design, javascript, pipeline, python, quality, security
 - **Key Capabilities**:
-  - **Problem**: Specific challenge the pattern addresses. Example: "Need CI/CD but can't invest 2 weeks in pipeline setup"
-  - **Solution**: Step-by-step implementation with decision points. Example: "Use GitHub Actions with templates from examples/ci-cd/, customize in 2 hours"
-  - **Consequences**: Benefits, trade-offs, limitations, maintenance burden. Example: "Fast setup but less flexibility than Jenkins, adequate for <10 engineers"
-
-### Templates (2 agents)
-
-#### `project-strategy-orchestrator`
-- **Path**: `agents/templates/project-strategy-orchestrator.md`
-- **Description**: Autonomous project analyzer and strategic setup decision maker
-- **Keywords**: ai, angular, api, architecture, cd, ci, database, devops, docker, frontend
-
-#### `team-assembly-orchestrator`
-- **Path**: `agents/templates/team-assembly-orchestrator.md`
-- **Description**: Assembles and coordinates specialized agent teams based on project needs
-- **Keywords**: api, architecture, database, design, devops, frontend, python, quality, react, security
+  - Team struggling with repeated architecture documentation violations
+  - New JavaScript team joining the AI-First SDLC framework
+  - Engineering manager wants to measure AI-First adoption effectiveness
 
 ### Testing (4 agents)
 
@@ -457,19 +561,35 @@
 - **Path**: `agents/testing/ai-test-engineer.md`
 - **Description**: Expert in comprehensive test strategy design, modern test automation frameworks, AI-augmented testing, contract testing, and quality engineering. Use for test pyramid design, CI/CD test integration, f...
 - **Keywords**: ai, angular, api, architecture, auth, aws, cd, ci, cloud, container
+- **Key Capabilities**:
+  - Team migrating to microservices architecture and needs a testing strategy that ensures service reliability and contract compatibility
+  - Development team experiencing frequent CI pipeline failures due to unreliable tests that pass locally but fail in CI
+  - Organization wants to accelerate testing without sacrificing coverage, exploring AI-assisted test generation
 
 #### `code-review-specialist`
 - **Path**: `agents/testing/code-review-specialist.md`
 - **Description**: Expert in code quality, security vulnerabilities (OWASP Top 10), language-specific patterns (Python/JS/Go/Java/Rust), and automated review tools. Use for PR reviews, security assessments, and review p...
 - **Keywords**: ai, api, architecture, auth, cd, ci, database, design, devops, go
+- **Key Capabilities**:
+  - Team has a PR touching authentication logic that needs security-focused review
+  - Developer wants to set up automated code review for a Python/TypeScript project
+  - Code changes in a PR include database migrations and need design review
 
 #### `integration-orchestrator`
 - **Path**: `agents/testing/integration-orchestrator.md`
 - **Description**: Expert in integration testing strategies, API contract testing (Pact, Spring Cloud Contract), service virtualization (WireMock, Mountebank), and E2E test orchestration. Use for designing multi-service...
 - **Keywords**: api, architecture, aws, cd, ci, cloud, container, database, design, devops
+- **Key Capabilities**:
+  - Team building microservices architecture with multiple service dependencies and needs comprehensive integration testing strategy
+  - Frontend and backend teams experiencing frequent integration issues after deployments despite passing unit tests
+  - Team needs to test complex user journeys across multiple services but E2E tests are flaky and slow
 
 #### `performance-engineer`
 - **Path**: `agents/testing/performance-engineer.md`
 - **Description**: Expert in performance testing, profiling, optimization, and capacity planning. Use for load testing strategy, bottleneck analysis, Core Web Vitals optimization, Kubernetes autoscaling, database query ...
 - **Keywords**: ai, api, architecture, aws, azure, cd, ci, cloud, container, database
+- **Key Capabilities**:
+  - Production API experiencing P95 latency above 500ms under normal load
+  - Planning for Black Friday traffic expecting 10x normal load
+  - Setting up performance testing in CI/CD pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,5 @@
 # CLAUDE.md
 
-All instructions have moved to **CLAUDE-CORE.md**.
+All rules are in **CONSTITUTION.md**. Core instructions are in **CLAUDE-CORE.md**.
 
-This file exists for CI compatibility only. Do not add content here.
-
-See **CLAUDE-CORE.md** for:
-- Framework core instructions and quick start
-- Team-first collaboration rules
-- Zero technical debt policy
-- Validation commands and workflow standards
+This file exists for CI compatibility. Do not add content here.

--- a/docs/feature-proposals/67-catalog-and-sync-fixes.md
+++ b/docs/feature-proposals/67-catalog-and-sync-fixes.md
@@ -1,0 +1,73 @@
+# Feature Proposal: Catalog Generator Fixes & Tooling
+
+**Proposal Number:** 67
+**Status:** In Progress
+**Author:** Claude (AI Agent)
+**Created:** 2026-02-10
+**Target Branch:** `feature/catalog-and-sync-fixes`
+
+---
+
+## Executive Summary
+
+Fix the AGENT-INDEX.md generator to produce clean capabilities and exclude template agents, create an agent sync script for `.claude/agents/`, add a broken-reference checker, and update the CLAUDE.md redirect.
+
+---
+
+## Motivation
+
+### Problem Statement
+
+- AGENT-INDEX.md capabilities contain raw markdown (`'<example>`, backtick commands) from regex-based extraction
+- Template agents (`project-strategy-orchestrator`, `team-assembly-orchestrator`) appear in the catalog as real agents
+- No automated way to sync `.claude/agents/` with `agents/` source tree
+- No tooling to detect broken file references after deletions
+
+### User Stories
+
+- As a developer browsing agents, I want clean capability descriptions without markdown artifacts
+- As a maintainer deleting files, I want to find all broken references before pushing
+
+---
+
+## Proposed Solution
+
+1. Fix `build-agent-catalog.py` to extract capabilities from YAML frontmatter examples
+2. Add `"templates" not in f.parts` to template filter
+3. Create `sync-claude-agents.py` for automated agent sync
+4. Create `check-broken-references.py` for reference validation
+5. Update `CLAUDE.md` to mention CONSTITUTION.md
+
+### Acceptance Criteria
+
+Given the AGENT-INDEX.md contains raw markdown in capabilities
+When the catalog generator is fixed and regenerated
+Then no capabilities contain `'<example>`, raw backtick commands, or multi-sentence prose
+
+Given template agents appear in the catalog
+When the filter is fixed
+Then agent count drops from 70 to 68 with no template agents listed
+
+Given no sync tooling exists
+When sync-claude-agents.py is created
+Then running it with --dry-run shows sync status without modifying files
+
+---
+
+## Success Criteria
+
+- [ ] AGENT-INDEX.md has clean capabilities from YAML examples
+- [ ] No template agents in catalog (68 agents, not 70)
+- [ ] sync-claude-agents.py works with --dry-run flag
+- [ ] check-broken-references.py reports zero broken refs in active files
+- [ ] CLAUDE.md mentions CONSTITUTION.md
+- [ ] All Python files compile
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Some agents lack YAML examples | Low | Falls back to cleaned regex extraction |
+| Broken-ref checker false positives | Medium | Exclude historical directories |

--- a/retrospectives/67-catalog-and-sync-fixes.md
+++ b/retrospectives/67-catalog-and-sync-fixes.md
@@ -1,0 +1,35 @@
+# Retrospective: Feature #67 — Catalog Generator Fixes & Tooling
+
+**Branch**: `feature/catalog-and-sync-fixes`
+**Date**: 2026-02-10
+
+## What Went Well
+
+- **YAML frontmatter for capabilities**: Extracting `examples[].context` from YAML produces clean, human-readable capabilities — far better than the regex approach that captured raw markdown
+- **Template filter was a one-liner**: Adding `"templates" not in f.parts` cleanly excluded the templates directory
+- **Sync script is minimal**: 60 lines, does exactly one thing, supports --dry-run
+- **Broken-reference checker is useful**: Even at v1, it found 106 real broken references across 31 files (aspirational doc links, setup-script path mismatches)
+
+## What Could Improve
+
+- **False positive tuning took iteration**: The broken-reference checker needed 3 rounds of refinement — initial run found 868 "broken" refs, mostly false positives from template/example content and Python scripts referencing runtime files
+- **User-project file exclusion list is large**: The exclusion set grew to 60+ filenames — a pattern-based approach (e.g., skip all `.json` refs in Python files) might be cleaner
+
+## Lessons Learned
+
+1. **YAML frontmatter is the right data source**: Agent files already have structured metadata — parsing it is always better than regex extraction from prose
+2. **Reference checking in a framework repo is hard**: This repo describes how to set up *other* projects, so most file references are to files that exist at runtime in user projects, not in this repo
+3. **Incremental exclusion lists work**: Starting with zero exclusions and adding categories based on actual false positives produces a well-tuned checker
+
+## Changes Made
+
+- `tools/automation/build-agent-catalog.py`: Extract capabilities from YAML examples, exclude templates directory
+- `AGENT-INDEX.md` + `AGENT-CATALOG.json`: Regenerated with clean data (68 agents)
+- `tools/automation/sync-claude-agents.py`: New — syncs agents/ to .claude/agents/
+- `tools/validation/check-broken-references.py`: New — detects broken file references
+- `CLAUDE.md`: Updated redirect to mention CONSTITUTION.md
+
+## Action Items
+
+- [ ] Address the 106 real broken references found by the checker (separate feature)
+- [ ] Consider adding check-broken-references.py to CI pipeline

--- a/tools/automation/sync-claude-agents.py
+++ b/tools/automation/sync-claude-agents.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Sync agents/ source tree to .claude/agents/ flat directory.
+
+Copies agent markdown files from the categorized agents/ directory
+to .claude/agents/ (flat structure) for Claude Code to discover.
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+
+def find_agent_sources(agents_dir: Path):
+    """Find all agent source files, excluding READMEs and templates."""
+    return sorted(
+        f
+        for f in agents_dir.rglob("*.md")
+        if "README" not in f.name
+        and "template" not in f.stem.lower()
+        and "templates" not in f.parts
+    )
+
+
+def sync_agents(dry_run: bool = False):
+    """Sync agents/ tree to .claude/agents/ flat directory."""
+    agents_dir = Path("agents")
+    target_dir = Path(".claude/agents")
+
+    if not agents_dir.exists():
+        print("Error: agents/ directory not found. Run from project root.")
+        return 1
+
+    if not dry_run:
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+    source_files = find_agent_sources(agents_dir)
+    added, updated, unchanged = 0, 0, 0
+
+    for src in source_files:
+        dest = target_dir / src.name
+        if not dest.exists():
+            if not dry_run:
+                shutil.copy2(src, dest)
+            print(f"  ADD: {src} -> {dest}")
+            added += 1
+        elif src.read_text(encoding="utf-8") != dest.read_text(encoding="utf-8"):
+            if not dry_run:
+                shutil.copy2(src, dest)
+            print(f"  UPDATE: {src} -> {dest}")
+            updated += 1
+        else:
+            unchanged += 1
+
+    prefix = "[DRY RUN] " if dry_run else ""
+    print(f"\n{prefix}Sync complete: {added} added, {updated} updated, {unchanged} unchanged")
+    print(f"Total agents in source: {len(source_files)}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Sync agents/ to .claude/agents/")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would change without modifying files"
+    )
+    args = parser.parse_args()
+    sys.exit(sync_agents(dry_run=args.dry_run))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validation/check-broken-references.py
+++ b/tools/validation/check-broken-references.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Check for broken file references across the project.
+
+Scans .md, .py, and .yml files for references to other project files
+and reports any that point to files that don't exist. Designed to catch
+stale references after file deletions/renames.
+
+Usage:
+    python tools/validation/check-broken-references.py          # Report only
+    python tools/validation/check-broken-references.py --strict  # Fail if broken refs found
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Directories containing historical content (past-tense references expected)
+HISTORICAL_DIRS = {
+    "retrospectives",
+    "docs/archive",
+    "docs/releases",
+    "docs/feature-proposals",
+    "tmp",
+}
+
+# Directories with example/template/instructional content that references user-project files
+EXAMPLE_DIRS = {
+    "examples", "v3", "plan", "tools/migration", "tools/orchestration",
+    "agent_prompts", "templates",
+}
+
+# Files commonly referenced in templates/examples but don't exist in this repo
+USER_PROJECT_FILES = {
+    # Config files
+    "package.json", "package-lock.json", "tsconfig.json", "pyproject.toml",
+    "requirements.txt", "composer.json", "Dockerfile", "docker-compose.yml",
+    "Makefile", ".ai-sdlc.json", "__init__.py", "config.json",
+    # CI configs
+    ".gitlab-ci.yml", "gitlab-ci.yml", "azure-pipelines.yml",
+    "Jenkinsfile", ".circleci/config.yml", ".travis.yml",
+    "bitbucket-pipelines.yml", ".drone.yml",
+    # Pre-commit
+    "pre-commit-config.yaml", ".pre-commit-config.yaml",
+    # Test/build files
+    "test-framework.sh", "test_framework_setup.py",
+    # AI instruction files
+    "GEMINI.md", "GPT.md",
+    # K8s/Helm
+    "deployment.yaml", "service.yaml", "configmap.yaml",
+    "ingress.yaml", "kustomization.yaml", "Chart.yaml",
+    # Runtime state files (created by scripts)
+    "level.json", "todos.json", "session.json", "current.json",
+    "context.json", "profiles.json", "installation-state.json",
+    "installation-todos.json", "agent-manifest.json",
+    "agent-version.json", ".agent-manifest.json",
+    ".agent-recommendations.json", ".claude-project.json",
+    "master_list.json", "last_assessment.json", "assessment_history.json",
+    "team-engagement-blocker.sh",
+    # Example source files
+    "main.py", "app.py", "index.ts", "index.js", "cli.py", "__main__.py",
+    "predict.py", "train.py", "model.py", "etl.py", "pipeline.py", "analysis.py",
+    "auth.py", "auth_utils.py", "auth_test.py",
+    # Config references
+    "claude_desktop_config.json", "mcp.json", ".claude/mcp.json",
+    "rubocop.yml", "auto-approve.yml", "sdlc-gates.yaml",
+    "gate-status.json", "agent-compositions.yaml",
+    "agent_memory.json", "agent_transitions.json", "collaborative_decisions.json",
+}
+
+# Architecture template filenames (referenced as targets for user projects to create)
+ARCHITECTURE_TEMPLATES = {
+    "requirements-traceability-matrix.md",
+    "what-if-analysis.md",
+    "architecture-decision-record.md",
+    "system-invariants.md",
+    "integration-design.md",
+    "failure-mode-analysis.md",
+}
+
+# File extensions to scan
+SCAN_EXTENSIONS = {".md", ".py", ".yml", ".yaml"}
+
+
+def is_excluded_dir(file_path: Path) -> bool:
+    """Check if a file is in a directory that should be skipped."""
+    path_str = str(file_path)
+    return any(path_str.startswith(d) for d in HISTORICAL_DIRS | EXAMPLE_DIRS)
+
+
+def is_known_template_ref(ref: str) -> bool:
+    """Check if a reference is a known user-project or template file."""
+    basename = Path(ref).name
+    return basename in USER_PROJECT_FILES or basename in ARCHITECTURE_TEMPLATES
+
+
+def strip_code_blocks(content: str) -> str:
+    """Remove fenced code blocks from markdown content."""
+    return re.sub(r"```[\s\S]*?```", "", content)
+
+
+def extract_references(content: str, file_ext: str) -> list:
+    """Extract file references from content outside code blocks."""
+    # Strip code blocks from markdown to avoid false positives
+    if file_ext == ".md":
+        content = strip_code_blocks(content)
+
+    refs = set()
+
+    # Markdown links: [text](path.ext)
+    for match in re.finditer(r"\[[^\]]*\]\(([^)]+)\)", content):
+        ref = match.group(1)
+        if not ref.startswith(("http", "mailto", "#")):
+            refs.add(ref)
+
+    # Backtick references: `path/to/file.ext`
+    for match in re.finditer(r"`([^`\s]+\.\w{1,5})`", content):
+        ref = match.group(1)
+        if any(ref.endswith(ext) for ext in SCAN_EXTENSIONS | {".json", ".sh"}):
+            refs.add(ref)
+
+    # Quoted string references in Python: "file.ext" or 'file.ext'
+    if file_ext == ".py":
+        for match in re.finditer(r"""["']([^"'\s]+\.\w{1,5})["']""", content):
+            ref = match.group(1)
+            if any(ref.endswith(ext) for ext in SCAN_EXTENSIONS | {".json", ".sh"}):
+                refs.add(ref)
+
+    return list(refs)
+
+
+def resolve_reference(ref: str, source_file: Path, project_root: Path) -> Path:
+    """Try to resolve a reference to an actual file path."""
+    # Try as relative to source file's directory
+    relative = source_file.parent / ref
+    if relative.exists():
+        return relative
+
+    # Try as relative to project root
+    from_root = project_root / ref
+    if from_root.exists():
+        return from_root
+
+    # Try searching common locations for bare filenames
+    if "/" not in ref:
+        for search_dir in ["tools/validation", "tools/automation", "docs", "templates", "."]:
+            candidate = project_root / search_dir / ref
+            if candidate.exists():
+                return candidate
+
+    return None
+
+
+def find_broken_references(strict: bool = False):
+    """Scan project for broken file references."""
+    project_root = Path(".")
+    broken = []
+    files_checked = 0
+
+    # Collect all scannable files
+    scan_files = []
+    for ext in SCAN_EXTENSIONS:
+        scan_files.extend(project_root.rglob(f"*{ext}"))
+
+    # Filter out hidden dirs (except .github), venv, node_modules, and excluded dirs
+    scan_files = [
+        f
+        for f in scan_files
+        if not any(
+            part.startswith(".") and part != "." and part != ".github"
+            for part in f.parts
+        )
+        and "venv" not in f.parts
+        and "node_modules" not in f.parts
+        and not is_excluded_dir(f)
+    ]
+
+    for file_path in sorted(scan_files):
+        try:
+            content = file_path.read_text(encoding="utf-8", errors="ignore")
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        files_checked += 1
+        refs = extract_references(content, file_path.suffix)
+
+        for ref in refs:
+            # Skip non-local references
+            if ref.startswith(("http", "mailto", "#", "{{", "$")):
+                continue
+            # Skip glob patterns and f-string templates
+            if "*" in ref or "{" in ref or "}" in ref:
+                continue
+            # Skip regex patterns and escaped characters
+            if "\\" in ref or "[" in ref:
+                continue
+            # Skip short generic names
+            if len(ref) < 5:
+                continue
+            # Skip known user-project and template references
+            if is_known_template_ref(ref):
+                continue
+            # Skip placeholder patterns (XX-name, template-*)
+            if "XX-" in ref or "template-" in ref.lower():
+                continue
+
+            resolved = resolve_reference(ref, file_path, project_root)
+            if resolved is None:
+                # Find line number
+                line_num = 0
+                for i, line in enumerate(content.splitlines(), 1):
+                    if ref in line:
+                        line_num = i
+                        break
+
+                broken.append(
+                    {"file": str(file_path), "line": line_num, "reference": ref}
+                )
+
+    print(f"Checked {files_checked} active files for broken references.\n")
+
+    if broken:
+        for b in sorted(broken, key=lambda x: (x["file"], x["line"])):
+            print(f"BROKEN: {b['file']}:{b['line']} -> {b['reference']}")
+
+        unique_files = len(set(b["file"] for b in broken))
+        print(f"\nFound {len(broken)} broken reference(s) in {unique_files} file(s).")
+        return 1 if strict else 0
+    else:
+        print("No broken references found.")
+        return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check for broken file references")
+    parser.add_argument(
+        "--strict", action="store_true", help="Exit with code 1 if broken references found"
+    )
+    args = parser.parse_args()
+    sys.exit(find_broken_references(strict=args.strict))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **Fix AGENT-INDEX.md capabilities**: Extract from YAML frontmatter `examples[].context` instead of buggy regex that captured raw markdown (`'<example>`, backtick commands). Falls back to cleaned regex when no YAML examples exist.
- **Exclude template agents**: Add `"templates" not in f.parts` to filter, dropping agent count from 70 to 68 (removes `project-strategy-orchestrator` and `team-assembly-orchestrator`)
- **Add `sync-claude-agents.py`**: Copies agents from categorized `agents/` tree to flat `.claude/agents/` directory. Supports `--dry-run` flag.
- **Add `check-broken-references.py`**: Scans active files for references to nonexistent files, excluding historical docs and known user-project references. Found 106 real broken references across 31 files.
- **Update `CLAUDE.md`**: 11→4 lines, now mentions CONSTITUTION.md

## Test plan

- [ ] Verify AGENT-INDEX.md has no raw `'<example>` tags in capabilities
- [ ] Verify agent count is 68 (no template agents)
- [ ] Run `python tools/automation/sync-claude-agents.py --dry-run` shows sync status
- [ ] Run `python tools/validation/check-broken-references.py` completes without error
- [ ] All Python files compile: `python -m py_compile tools/automation/build-agent-catalog.py tools/automation/sync-claude-agents.py tools/validation/check-broken-references.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)