### PR TITLE
feat: enable model invocation on 13 SDLC skills (closes #139)

### DIFF
--- a/docs/feature-proposals/139-enable-model-invocation.md
+++ b/docs/feature-proposals/139-enable-model-invocation.md
@@ -12,9 +12,25 @@
 
 ## Executive Summary
 
-Flip `disable-model-invocation` from `true` to `false` on 13 of 15 SDLC framework skills. The whole point of skills is that models invoke them proactively in the natural flow of work. With the flag true on every skill, Claude cannot auto-invoke any of them and users must remember to type the slash command for every workflow step. This undermines the framework's value proposition — particularly for `kb-query`, where auto-invocation means the library's "grounded in evidence" value is delivered automatically rather than requiring the user to type `/sdlc-knowledge-base:kb-query` every time.
+Flip `disable-model-invocation` from `true` to `false` on 13 of 15 SDLC framework skills so Claude can auto-invoke them in the natural flow of work.
 
-Keep `commit` and `pr` as explicit-only because they create git commits and remote PRs — real actions visible to others that should always be explicit user intent. All other skills are either read-only or additive-idempotent and safe for model invocation.
+---
+
+## Motivation
+
+All 15 SDLC skills have `disable-model-invocation: true`, meaning Claude cannot auto-invoke any of them — users must type the slash command explicitly for every workflow step. This undermines the framework's value proposition: the whole point of skills is that models invoke them proactively.
+
+The highest-impact case is `kb-query`: with the flag true, every user research question gets answered from Claude's training data (possibly hallucinating) unless the user remembers to type `/sdlc-knowledge-base:kb-query`. With the flag false, Claude auto-queries the library when a research question matches — the library's "grounded in evidence" value is delivered automatically.
+
+Similar for `validate` (should auto-run after edits per CLAUDE.md workflow), `new-feature` (should enforce "create proposal before coding"), and `setup-team` (should auto-invoke when a user is clearly configuring a new project).
+
+The previous rationale for keeping the flag true ("these skills take real actions") didn't hold up to examination: almost all of them are either read-only or additive-idempotent. Only `commit` (git commit) and `pr` (remote PR creation) have real destructive consequences and should stay explicit.
+
+---
+
+## Proposed Solution
+
+Flip `disable-model-invocation` from `true` to `false` on 13 source skill files and their 13 plugin copies. Keep `commit` and `pr` as `true`. Pure frontmatter change — one line per file.
 
 ---
 

--- a/docs/feature-proposals/139-enable-model-invocation.md
+++ b/docs/feature-proposals/139-enable-model-invocation.md
@@ -1,0 +1,37 @@
+# Feature Proposal: Enable Model Invocation on SDLC Skills
+
+**Proposal Number:** 139
+**Status:** In Progress
+**Author:** Claude (AI Agent) and Steve Jones
+**Created:** 2026-04-09
+**Target Branch:** `fix/enable-model-invocation`
+**Issue:** #139
+**Type:** Enhancement
+
+---
+
+## Executive Summary
+
+Flip `disable-model-invocation` from `true` to `false` on 13 of 15 SDLC framework skills. The whole point of skills is that models invoke them proactively in the natural flow of work. With the flag true on every skill, Claude cannot auto-invoke any of them and users must remember to type the slash command for every workflow step. This undermines the framework's value proposition — particularly for `kb-query`, where auto-invocation means the library's "grounded in evidence" value is delivered automatically rather than requiring the user to type `/sdlc-knowledge-base:kb-query` every time.
+
+Keep `commit` and `pr` as explicit-only because they create git commits and remote PRs — real actions visible to others that should always be explicit user intent. All other skills are either read-only or additive-idempotent and safe for model invocation.
+
+---
+
+## Success Criteria
+
+- [ ] 13 source skill files have `disable-model-invocation: false`
+- [ ] 13 plugin copies match the source
+- [ ] `commit` and `pr` retain `disable-model-invocation: true`
+- [ ] `python3 tools/validation/check-plugin-packaging.py` passes
+- [ ] CI passes
+
+---
+
+## Changes Made
+
+| Action | File |
+|--------|------|
+| Modify | 13 source skill files under `skills/` (one line each) |
+| Modify | 13 plugin copy files under `plugins/sdlc-core/skills/` and `plugins/sdlc-knowledge-base/skills/` |
+| Create | `docs/feature-proposals/139-enable-model-invocation.md` (this file) |

--- a/plugins/sdlc-core/skills/new-feature/SKILL.md
+++ b/plugins/sdlc-core/skills/new-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-feature
 description: Create a new feature with proposal, retrospective, and branch. Use when starting new development work.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<number> <name> [title]"
 ---
 

--- a/plugins/sdlc-core/skills/release-plugin/SKILL.md
+++ b/plugins/sdlc-core/skills/release-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release-plugin
 description: Package source files into plugin directories using release-mapping.yaml. Use when preparing a plugin release.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[patch | minor | major]"
 ---
 

--- a/plugins/sdlc-core/skills/setup-ci/SKILL.md
+++ b/plugins/sdlc-core/skills/setup-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-ci
 description: Generate a GitHub Actions workflow for SDLC validation. Use when setting up CI/CD for a new project.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[python | javascript | go]"
 ---
 

--- a/plugins/sdlc-core/skills/setup-team/SKILL.md
+++ b/plugins/sdlc-core/skills/setup-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-team
 description: Configure SDLC team formation for this project. Recommends and installs team plugins based on project type.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # SDLC Team Setup

--- a/plugins/sdlc-core/skills/validate/SKILL.md
+++ b/plugins/sdlc-core/skills/validate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate
 description: Run the SDLC validation pipeline using direct tool invocations. No wrapper scripts required. Use when checking code quality before commits or PRs.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--syntax | --quick | --pre-push]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-ingest/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-ingest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-ingest
 description: Integrate a new source into the project knowledge base. Wraps the agent-knowledge-updater agent. Source can be a local file path, a URL, or pasted content. The updater reads the source, classifies it, identifies which existing library files it touches, makes surgical updates or creates new files, rebuilds the shelf-index, and appends to log.md.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<source-path-or-url-or-text>"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-init/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-init
 description: Initialise a project for knowledge base use. Appends the [Knowledge Base] section to the project's CLAUDE.md, creates the library/ directory structure, optionally seeds with three example library files from the Agentic SDLC research, and reports next steps. Run once after installing sdlc-knowledge-base.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--with-starter-pack | --empty]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-lint/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-lint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-lint
 description: Health-check the project knowledge base. Looks for contradictions between files, stale claims that newer sources have superseded, orphan files with no inbound cross-references, important concepts mentioned but lacking their own page, missing cross-references, and data gaps. Returns a structured report; does not auto-fix.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--scope <pattern>]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-promote-answer-to-library/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-promote-answer-to-library/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-promote-answer-to-library
 description: File a librarian query result back into the library as a new page with provenance tracking. Karpathy's "good answers can be filed back into the wiki as new pages" insight made concrete. The library compounds from explorations, not just from external sources.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<query-result-text-or-file> [--title <title>] [--path <library-file-path>]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-query/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-query
 description: Query the project knowledge base. Wraps the research-librarian agent. The librarian reads the shelf-index, identifies the 2-4 most relevant library files for the question, deep-reads only those, and returns structured evidence with citations. Stateless — reads the index fresh on every query.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<question> [--promote-to-library]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-rebuild-indexes/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-rebuild-indexes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-rebuild-indexes
 description: Rebuild the knowledge base shelf-index with hash-based change detection. Incremental by default — only re-extracts files whose content has changed since the last index. Use after ingesting new sources, after editing library files, or whenever the librarian agent reports a stale index.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--full]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-staleness-check/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-staleness-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-staleness-check
 description: Check whether the knowledge base shelf-index is stale relative to the library files. Reports drifted entries without rebuilding. Designed to be invoked from environment validation or pre-push hooks as an opt-in check. Default mode is warning; strict mode fails with non-zero exit when any drift is detected.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--strict]"
 ---
 

--- a/plugins/sdlc-knowledge-base/skills/kb-validate-citations/SKILL.md
+++ b/plugins/sdlc-knowledge-base/skills/kb-validate-citations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-validate-citations
 description: Spot-check citations in library files for obvious hallucinations. Resolves DOIs against the DOI registry, validates arXiv IDs, checks the format of journal references. Soft-fails on transient lookup failures rather than blocking. Recommended after kb-ingest and as part of periodic library hygiene.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[<file-path-or-glob>]"
 ---
 

--- a/skills/kb-ingest/SKILL.md
+++ b/skills/kb-ingest/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-ingest
 description: Integrate a new source into the project knowledge base. Wraps the agent-knowledge-updater agent. Source can be a local file path, a URL, or pasted content. The updater reads the source, classifies it, identifies which existing library files it touches, makes surgical updates or creates new files, rebuilds the shelf-index, and appends to log.md.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<source-path-or-url-or-text>"
 ---
 

--- a/skills/kb-init/SKILL.md
+++ b/skills/kb-init/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-init
 description: Initialise a project for knowledge base use. Appends the [Knowledge Base] section to the project's CLAUDE.md, creates the library/ directory structure, optionally seeds with three example library files from the Agentic SDLC research, and reports next steps. Run once after installing sdlc-knowledge-base.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--with-starter-pack | --empty]"
 ---
 

--- a/skills/kb-lint/SKILL.md
+++ b/skills/kb-lint/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-lint
 description: Health-check the project knowledge base. Looks for contradictions between files, stale claims that newer sources have superseded, orphan files with no inbound cross-references, important concepts mentioned but lacking their own page, missing cross-references, and data gaps. Returns a structured report; does not auto-fix.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--scope <pattern>]"
 ---
 

--- a/skills/kb-promote-answer-to-library/SKILL.md
+++ b/skills/kb-promote-answer-to-library/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-promote-answer-to-library
 description: File a librarian query result back into the library as a new page with provenance tracking. Karpathy's "good answers can be filed back into the wiki as new pages" insight made concrete. The library compounds from explorations, not just from external sources.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<query-result-text-or-file> [--title <title>] [--path <library-file-path>]"
 ---
 

--- a/skills/kb-query/SKILL.md
+++ b/skills/kb-query/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-query
 description: Query the project knowledge base. Wraps the research-librarian agent. The librarian reads the shelf-index, identifies the 2-4 most relevant library files for the question, deep-reads only those, and returns structured evidence with citations. Stateless — reads the index fresh on every query.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<question> [--promote-to-library]"
 ---
 

--- a/skills/kb-rebuild-indexes/SKILL.md
+++ b/skills/kb-rebuild-indexes/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-rebuild-indexes
 description: Rebuild the knowledge base shelf-index with hash-based change detection. Incremental by default — only re-extracts files whose content has changed since the last index. Use after ingesting new sources, after editing library files, or whenever the librarian agent reports a stale index.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--full]"
 ---
 

--- a/skills/kb-staleness-check/SKILL.md
+++ b/skills/kb-staleness-check/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-staleness-check
 description: Check whether the knowledge base shelf-index is stale relative to the library files. Reports drifted entries without rebuilding. Designed to be invoked from environment validation or pre-push hooks as an opt-in check. Default mode is warning; strict mode fails with non-zero exit when any drift is detected.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--strict]"
 ---
 

--- a/skills/kb-validate-citations/SKILL.md
+++ b/skills/kb-validate-citations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-validate-citations
 description: Spot-check citations in library files for obvious hallucinations. Resolves DOIs against the DOI registry, validates arXiv IDs, checks the format of journal references. Soft-fails on transient lookup failures rather than blocking. Recommended after kb-ingest and as part of periodic library hygiene.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[<file-path-or-glob>]"
 ---
 

--- a/skills/new-feature/SKILL.md
+++ b/skills/new-feature/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: new-feature
 description: Create a new feature with proposal, retrospective, and branch. Use when starting new development work.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "<number> <name> [title]"
 ---
 

--- a/skills/release-plugin/SKILL.md
+++ b/skills/release-plugin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release-plugin
 description: Package source files into plugin directories using release-mapping.yaml. Use when preparing a plugin release.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[patch | minor | major]"
 ---
 

--- a/skills/setup-ci/SKILL.md
+++ b/skills/setup-ci/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-ci
 description: Generate a GitHub Actions workflow for SDLC validation. Use when setting up CI/CD for a new project.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[python | javascript | go]"
 ---
 

--- a/skills/setup-team/SKILL.md
+++ b/skills/setup-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-team
 description: Configure SDLC team formation for this project. Recommends and installs team plugins based on project type.
-disable-model-invocation: true
+disable-model-invocation: false
 ---
 
 # SDLC Team Setup

--- a/skills/validate/SKILL.md
+++ b/skills/validate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: validate
 description: Run the SDLC validation pipeline using direct tool invocations. No wrapper scripts required. Use when checking code quality before commits or PRs.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[--syntax | --quick | --pre-push]"
 ---
 


### PR DESCRIPTION
## Summary

Flips \`disable-model-invocation\` from \`true\` to \`false\` on 13 of 15 skills so Claude can auto-invoke them proactively in the natural flow of work. Keeps \`commit\` and \`pr\` as explicit-only (they create git commits and remote PRs — real actions that should be user-initiated).

## Why

The whole point of skills is that models use them. With the flag \`true\`, Claude cannot auto-invoke any skill — every workflow step requires the user to type the slash command. This undermines the framework's value proposition.

**The highest-value case is \`kb-query\`**: with the flag \`true\`, user research questions get answered from Claude's training data (possibly hallucinating) unless the user remembers to type \`/sdlc-knowledge-base:kb-query\`. With the flag \`false\`, Claude auto-queries the library when a research question matches — the library's "grounded in evidence" value is delivered automatically.

Similar arguments for other skills: \`validate\` should auto-run after edits per the CLAUDE.md workflow rule. \`new-feature\` should auto-invoke when a user starts new work. The framework's own documented workflow implies automatic invocation.

## What changes

26 files changed (13 source + 13 plugin copies). Each change is one line: \`disable-model-invocation: true\` → \`disable-model-invocation: false\`.

### Flipped to \`false\` (13 skills)

| Skill | Plugin | Why auto-invokable |
|---|---|---|
| \`validate\` | sdlc-core | Read-only validation reports; should auto-run per CLAUDE.md workflow |
| \`new-feature\` | sdlc-core | Establishes framework workflow; enforce "create proposal before coding" |
| \`setup-ci\` | sdlc-core | One-time, additive |
| \`setup-team\` | sdlc-core | One-time; asks its own questions for user consent |
| \`release-plugin\` | sdlc-core | Idempotent sync of derived files |
| \`kb-query\` | sdlc-knowledge-base | **Highest-value flip** — library auto-grounding |
| \`kb-init\` | sdlc-knowledge-base | Idempotent with "already initialized" check |
| \`kb-ingest\` | sdlc-knowledge-base | Opinionated updater asks when uncertain |
| \`kb-lint\` | sdlc-knowledge-base | Read-only health check |
| \`kb-rebuild-indexes\` | sdlc-knowledge-base | Idempotent on derived artifact |
| \`kb-validate-citations\` | sdlc-knowledge-base | Read-only |
| \`kb-promote-answer-to-library\` | sdlc-knowledge-base | Explicit via --promote flag |
| \`kb-staleness-check\` | sdlc-knowledge-base | Read-only |

### Kept as \`true\` (2 skills)

| Skill | Plugin | Why explicit-only |
|---|---|---|
| \`commit\` | sdlc-core | Creates git commits — explicit user intent |
| \`pr\` | sdlc-core | Creates remote PRs visible to others |

### Already auto-invokable

| Skill | Plugin | Notes |
|---|---|---|
| \`rules\` | sdlc-core | No field = default false; reference lookup |

## Test plan

- [x] 13 source files flipped to \`false\`
- [x] 13 plugin copies synced from source
- [x] \`commit\` and \`pr\` verified still \`true\`
- [x] \`python3 tools/validation/check-plugin-packaging.py\` — 11/11 plugins pass
- [ ] CI passes

## Post-merge verification

After merge + \`/plugin marketplace update ai-first-sdlc\` + \`/reload-plugins\`:

1. Ask Claude a research question (e.g., "what does the research say about specification formality?") — expected: Claude auto-invokes kb-query and returns library-grounded evidence
2. Start working on a new feature without typing \`/sdlc-core:new-feature\` — expected: Claude proactively invokes the new-feature skill
3. Edit code and wait — expected: Claude proactively invokes validate (at least \`--syntax\` level)

If any of these doesn't trigger, the skill descriptions may need adjustment for better matching (separate issue, not in scope here — the flag flip is correct regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)