### PR TITLE
feat: enable model invocation on commit skill (refs #139)

### DIFF
--- a/docs/feature-proposals/139-enable-model-invocation.md
+++ b/docs/feature-proposals/139-enable-model-invocation.md
@@ -48,6 +48,8 @@ Flip `disable-model-invocation` from `true` to `false` on 13 source skill files 
 
 | Action | File |
 |--------|------|
-| Modify | 13 source skill files under `skills/` (one line each) |
-| Modify | 13 plugin copy files under `plugins/sdlc-core/skills/` and `plugins/sdlc-knowledge-base/skills/` |
+| Modify | 14 source skill files under `skills/` (one line each — 13 in PR #140 + `commit` in follow-up PR) |
+| Modify | 14 plugin copy files under `plugins/sdlc-core/skills/` and `plugins/sdlc-knowledge-base/skills/` |
 | Create | `docs/feature-proposals/139-enable-model-invocation.md` (this file) |
+
+**Note:** The initial PR (#140) flipped 13 skills but kept `commit` as explicit-only. Steve challenged this: "a commit is a local checkpoint, not a publication — it doesn't overwrite anything, it just means better history." He was right. A follow-up PR flips `commit` to `false` as well. Only `pr` remains `disable-model-invocation: true`.

--- a/docs/feature-proposals/139-enable-model-invocation.md
+++ b/docs/feature-proposals/139-enable-model-invocation.md
@@ -4,7 +4,7 @@
 **Status:** In Progress
 **Author:** Claude (AI Agent) and Steve Jones
 **Created:** 2026-04-09
-**Target Branch:** `fix/enable-model-invocation`
+**Target Branch:** `fix/enable-model-invocation`, `fix/enable-commit-model-invocation`
 **Issue:** #139
 **Type:** Enhancement
 

--- a/plugins/sdlc-core/skills/commit/SKILL.md
+++ b/plugins/sdlc-core/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Validated commit — runs quick checks before committing. Use when ready to commit changes.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[commit message]"
 ---
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: commit
 description: Validated commit — runs quick checks before committing. Use when ready to commit changes.
-disable-model-invocation: true
+disable-model-invocation: false
 argument-hint: "[commit message]"
 ---
 


### PR DESCRIPTION
## Summary

Flips \`disable-model-invocation\` from \`true\` to \`false\` on the \`commit\` skill. Follow-up to PR #140 which flipped 13 skills but kept \`commit\` and \`pr\` as explicit-only.

Steve challenged: "Why is git commit an approval? That doesn't overwrite anything, it just means we have a better history of change." He's right.

A commit is a local checkpoint, not a publication. It doesn't push anywhere, doesn't create anything visible to others, and the \`commit\` skill runs validation before committing so it won't commit broken code. More frequent commits = better granularity = easier to bisect, revert, and understand.

**The only skill that remains \`disable-model-invocation: true\` is \`pr\`** — the one that creates something remote and visible to others.

## Changes

2 files changed (source + plugin copy), 1 line each.

## Test plan

- [x] \`commit\` skill flipped to \`false\`
- [x] Plugin copy synced
- [x] \`pr\` verified still \`true\`
- [x] \`check-plugin-packaging.py\` passes (11/11)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)