### PR TITLE
docs(192): add agentic-delivery use case to sdlc-assured positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Then configure your team: `/sdlc-core:setup-team`
 | `sdlc-lang-javascript` | JavaScript/TypeScript language expert agent |
 | `sdlc-workflows` | Containerised delegation — Archon-orchestrated DAG workflows in isolated Docker containers (6 skills) |
 | `sdlc-programme` | Method 1 SDLC bundle for multi-team programme work — formal waterfall phase gates (requirements/design/test/code), 4 phase-gate validators, mandatory cross-phase review (5 skills, EPIC #178 v0.1.0) |
-| `sdlc-assured` | Method 2 SDLC bundle for regulated-industry work — positional namespace IDs, bidirectional traceability, DDD decomposition with visibility rules, KB-for-code annotations, standard-specific exports (DO-178C / IEC 62304 / ISO 26262 / FDA DHF). 8 skills. **v0.2.0 audit-ready at tooling layer** (EPIC #188) — typed evidence statuses, multi-format evidence model (Python/markdown/YAML/satisfies-by-existence), platform-neutral dependency extractor, indirect DES-mediated coverage, REQ-quality lint candidate. |
+| `sdlc-assured` | Method 2 SDLC bundle for regulated-industry work **or** complex agentic systems at scale (10+ bounded contexts) — positional namespace IDs, bidirectional traceability, DDD decomposition with visibility rules, KB-for-code annotations, standard-specific exports (DO-178C / IEC 62304 / ISO 26262 / FDA DHF). 8 skills. **v0.2.0 audit-ready at tooling layer** (EPIC #188) — typed evidence statuses, multi-format evidence model (Python/markdown/YAML/satisfies-by-existence), platform-neutral dependency extractor, indirect DES-mediated coverage, REQ-quality lint candidate. |
 
 ### Available Skills
 

--- a/docs/METHODS-GUIDE.md
+++ b/docs/METHODS-GUIDE.md
@@ -61,7 +61,7 @@ The framework's `/sdlc-core:commission` skill walks projects through commissioni
 | **Solo** | 1–2 contributors, fast iteration, lightweight constitution overlay. |
 | **Single-team** | 3–10 contributors, organic delivery — the framework default. |
 | **Programme** (Method 1) | 11–50 across 2–5 teams, formal phase gates, mandatory cross-phase review. |
-| **Assured** (Method 2) | Regulated industries (DO-178C, IEC 62304, ISO 26262, FDA 21 CFR Part 820); audit-ready traceability + decomposition + typed evidence. |
+| **Assured** (Method 2) | Regulated industries **or** complex agentic systems at scale (10+ bounded contexts; scoped context per agent); audit-ready traceability + decomposition + typed evidence. |
 
 The choice is **orthogonal to team plugin selection**. A regulated medical-device project might be `cloud-infrastructure` (project type C in `setup-team`) **and** `assured` (SDLC method D); an AI/ML prototype might be `ai-ml` (project type B) **and** `solo` (SDLC method B). Project type drives team plugin selection; SDLC method drives delivery discipline.
 
@@ -73,9 +73,9 @@ You don't have to pick at setup time — `setup-team` accepts "Decide later" and
 
 Answer the questions in order; the first match wins.
 
-**1. Are you targeting a regulated industry?** (DO-178C avionics, IEC 62304 medical devices, ISO 26262 automotive, IEC 61508 functional safety, FDA 21 CFR Part 820)
+**1. Are you targeting a regulated industry** (DO-178C avionics, IEC 62304 medical devices, ISO 26262 automotive, IEC 61508 functional safety, FDA 21 CFR Part 820) **— or — building a complex agentic system with 10+ bounded contexts** where you need to give each agent a scoped context slice rather than the whole system (to prevent mis-implementation from "knowing too much")?
 
-- **Yes** → use [**Assured (Method 2)**](#assured-method-2). Stop here.
+- **Yes to either** → use [**Assured (Method 2)**](#assured-method-2). Stop here.
 - **No** → continue.
 
 **2. Do you need formal cross-team sign-off on phase artefacts?** (typically: 11+ contributors, **or** 2 or more sub-teams that must explicitly approve each other's design / test artefacts)
@@ -254,11 +254,22 @@ If you need any of those, pick Assured.
 
 ### When to use
 
+**Regulated industries** — any of these apply:
+
 - Target standards: **DO-178C** (avionics), **IEC 62304** (medical devices), **ISO 26262** (automotive), **IEC 61508** (functional safety), **FDA 21 CFR Part 820** (medical devices)
 - Audit requirement: audit-ready bidirectional traceability, positional IDs, decomposition visibility, typed evidence
+- Regulator context: FAA, EASA, FDA, notified body, certification agency
+
+**Complex agentic systems at scale** — any of these apply:
+
+- 10 or more bounded contexts / modules where routing each agent to a scoped slice reduces mis-implementation
+- You need KB-for-code (`# implements:` annotations) to give agents a requirements-grounded context slice without loading the entire codebase
+- Decomposition visibility enforcement across module boundaries is operationally valuable, regardless of any audit requirement
+
+**Common to both**:
+
 - Specification maturity: formal, requirement-driven
 - Team size: any (the bundle scales from one engineer up to multi-team programmes)
-- Regulator context: FAA, EASA, FDA, notified body, certification agency
 
 ### What Method 2 adds over Method 1
 
@@ -332,7 +343,7 @@ For a full breakdown of what's automated vs. what requires manual evidence vs. w
 | Constitution articles | 1–11 (overlay relaxes some) | 1–11 | 1–11 + 12–14 | 1–11 + 12–14 + 15–17 |
 | Regulatory support | None | None | None | DO-178C, IEC 62304, ISO 26262, IEC 61508, FDA 21 CFR Part 820 |
 | Commission command | `/sdlc-core:commission --option solo` | (none — default) | `/sdlc-core:commission --option programme` | `/sdlc-core:commission --option assured` |
-| When to pick | Solo / experimental | Most projects (default) | Multi-team, formal spec | Regulated industry |
+| When to pick | Solo / experimental | Most projects (default) | Multi-team, formal spec | Regulated industry OR complex agentic system (10+ bounded contexts) |
 
 ---
 

--- a/docs/feature-proposals/192-sdlc-assured-agentic-framing.md
+++ b/docs/feature-proposals/192-sdlc-assured-agentic-framing.md
@@ -1,0 +1,80 @@
+# Feature Proposal: sdlc-assured Agentic-Delivery Use Case
+
+**Proposal Number:** 192
+**Status:** In Progress
+**Author:** Claude (AI Agent)
+**Created:** 2026-05-02
+**Target Branch:** `feature/192-sdlc-assured-agentic-framing`
+
+---
+
+## Executive Summary
+
+The sdlc-assured docs currently frame the bundle almost exclusively as "for regulated industries" (DO-178C, IEC 62304, ISO 26262, FDA DHF). The original design intent (METHODS.md §2) included a second, equally valid use case: complex agentic systems with bounded-context decomposition needs. This fix adds a parallel use-case block to the README and METHODS-GUIDE so that agentic-delivery teams self-select correctly instead of skipping the bundle.
+
+---
+
+## Motivation
+
+### Problem Statement
+
+The METHODS.md design doc (research/sdlc-bundles/METHODS.md §2) states two motivations for Method 2 (Assured):
+
+1. Regulated-industries traceability — "individual identification of requirements, design elements etc to give full traceability of code back to requirements"
+2. Agentic delivery at scale — "uses similar approaches to our knowledge base to enable access to those requirements... optimising the context window... a smaller context [for the agent], and be less prone to misimplementing requirements because it 'knows too much'"
+
+PR #191 (v0.2.0 adoption surface) positioned the bundle almost entirely on motivation 1. A reader of `plugins/sdlc-assured/README.md` or `docs/METHODS-GUIDE.md` today would conclude "this is for medical-device / avionics / automotive teams" and skip it if building a non-regulated agentic system — even though the bundle was designed with that use case in mind. The docs aren't wrong; they're just narrowly framed.
+
+### User Stories
+
+- As a team building a complex multi-agent platform (non-regulated), I want to understand whether sdlc-assured applies to me so that I can make an informed SDLC method choice.
+- As a solo developer building a large agentic system with hundreds of bounded contexts, I want to know that sdlc-assured's positional IDs + KB-for-code + decomposition validators exist for context-window management — not just audit trail — so that I can evaluate the bundle on its merits for my use case.
+
+---
+
+## Proposed Solution
+
+1. Add a "Use Assured when" block in `plugins/sdlc-assured/README.md` that lists both use cases side by side: (a) regulated industries and (b) complex agentic systems with bounded-context decomposition needs. Explain the underlying value prop — "give each agent a small scoped slice rather than the whole system in context" — in plain terms.
+
+2. Update `docs/METHODS-GUIDE.md` in the Method 2 section to mirror the same dual framing, so the decision tree steers agentic teams toward Assured where appropriate.
+
+3. No renaming, no API changes, no new validators. Doc-only change.
+
+### Acceptance Criteria
+
+Given a reader building a complex non-regulated agentic system  
+When they read `plugins/sdlc-assured/README.md`  
+Then they see a clear "use Assured for: agentic systems at scale" block alongside the regulated-industries block
+
+Given a reader using `docs/METHODS-GUIDE.md` to pick an SDLC method  
+When they reach the Method 2 / Assured entry  
+Then the description names both regulated-industries AND agentic-scale as trigger conditions
+
+---
+
+## Success Criteria
+
+- [ ] `plugins/sdlc-assured/README.md` has a "Use Assured when" or equivalent section that explicitly names the agentic-delivery use case
+- [ ] `docs/METHODS-GUIDE.md` Method 2 description names both use cases
+- [ ] All existing tests still pass (`pytest`)
+- [ ] `check-broken-references.py` passes (no new broken links)
+- [ ] Docs reviewed and approved
+
+---
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Over-broadening — making Assured sound like the default for all projects | Low adoption of simpler methods | Keep framing conditional ("if you have 10+ bounded contexts…") |
+| Inconsistency with CLAUDE.md / AGENT-INDEX.md descriptions | Reader confusion | Update CLAUDE.md and AGENT-INDEX.md descriptions if they repeat the narrow framing |
+
+---
+
+## Changes Made
+
+| Action | File |
+|--------|------|
+| Modify | `plugins/sdlc-assured/README.md` |
+| Modify | `docs/METHODS-GUIDE.md` |
+| Modify | `CLAUDE.md` (if sdlc-assured description repeats narrow framing) |

--- a/plugins/sdlc-assured/README.md
+++ b/plugins/sdlc-assured/README.md
@@ -1,8 +1,18 @@
 # sdlc-assured (v0.2.0 — audit-ready at the tooling layer)
 
-Regulated-industry SDLC bundle (Method 2) for projects targeting DO-178C, IEC 62304, ISO 26262, IEC 61508, or FDA 21 CFR Part 820. Layers on top of `sdlc-programme` (Method 1) with positional namespace IDs, bidirectional traceability, DDD-style decomposition with visibility rules, KB extension to code, typed evidence statuses, and standard-specific traceability exports.
+SDLC bundle (Method 2) for regulated-industry projects and complex agentic systems at scale. Layers on top of `sdlc-programme` (Method 1) with positional namespace IDs, bidirectional traceability, DDD-style decomposition with visibility rules, KB extension to code, typed evidence statuses, and standard-specific traceability exports.
 
 **v0.2.0 status**: audit-ready at the tooling layer. The validators, traceability machinery, evidence model, and exports are deterministic and regenerable by an auditor from the source tree. Two of four carry-forward items — corpus-policy CI enforcement and CI integration of the REQ-quality linter — are deferred to v0.3.0; see [Audit-Ready at the Tooling Layer (v0.2.0)](#audit-ready-at-the-tooling-layer-v020) below for the full list of what is and is not in scope.
+
+## Use Assured when
+
+**Regulated industries** — you are targeting a certification standard (DO-178C, IEC 62304, ISO 26262, IEC 61508, FDA 21 CFR Part 820) and need auditor-regenerable artefacts: bidirectional traceability, positional IDs, typed evidence, and standard-specific exports.
+
+**Complex agentic systems at scale** — you are building a system with 10 or more bounded contexts (modules) and want to give each agent a scoped context slice rather than the whole system. The original design motivation for Method 2 included this explicitly: positional IDs + KB-for-code + decomposition validators let you route each agent to its relevant module with a small, scoped requirement slice, reducing the risk that an agent "knows too much" and mis-implements by hallucinating against unrelated system context. No regulatory requirement is needed to benefit from this.
+
+If neither condition applies, use [Programme (Method 1)](../../docs/METHODS-GUIDE.md#programme-method-1) for multi-team coordination or [Single-team](../../docs/METHODS-GUIDE.md#single-team) for most projects.
+
+---
 
 ## What this bundle adds over Programme
 

--- a/retrospectives/192-sdlc-assured-agentic-framing.md
+++ b/retrospectives/192-sdlc-assured-agentic-framing.md
@@ -1,0 +1,29 @@
+# Retrospective: Feature #192 — sdlc-assured Agentic-Delivery Use Case
+
+**Branch**: `feature/192-sdlc-assured-agentic-framing`
+**Date**: 2026-05-02
+
+## What Went Well
+
+- Root cause was clearly traceable to METHODS.md §2 (the original design doc), which named both motivations explicitly — made the fix unambiguous
+- All three files updated consistently: README intro, "Use Assured when" section, METHODS-GUIDE overview table + decision tree + "When to use" + comparison table, and CLAUDE.md plugin table
+- No new broken references introduced; 599/599 tests pass
+
+## What Could Improve
+
+- Narrowed framing was introduced gradually across three PRs (#178, #188, #191) rather than as a single decision — harder to catch in review when it accumulates incrementally
+
+## Lessons Learned
+
+1. When a bundle has two independent origin motivations, position them explicitly in parallel from the start — retrofitting the second framing is more work than stating both upfront
+
+## Changes Made
+
+- `plugins/sdlc-assured/README.md`: Updated intro line; added "Use Assured when" section naming both use cases
+- `docs/METHODS-GUIDE.md`: Updated overview table, decision tree Q1, Assured "When to use" section, and comparison table "When to pick" row
+- `CLAUDE.md`: Updated sdlc-assured plugin table entry
+
+## Metrics
+
+- **Files modified**: 3
+- **Files created**: 2 (feature proposal + retrospective)


### PR DESCRIPTION
## Summary

- `sdlc-assured` docs narrowly framed the bundle as "for regulated industries" (DO-178C, IEC 62304, ISO 26262, FDA), but the original design intent (METHODS.md §2) named two motivations: regulated-industry traceability AND complex agentic systems at scale where giving each agent a scoped context slice prevents mis-implementation from "knowing too much"
- PR #191 shipped the adoption surface but leaned almost entirely on the regulatory framing — non-regulated agentic teams would self-select out incorrectly
- This PR adds the second use case in parallel throughout the docs, without renaming or API changes

## Changes

- `plugins/sdlc-assured/README.md`: updated intro line; new **"Use Assured when"** section with two parallel blocks (regulated industries / complex agentic systems)
- `docs/METHODS-GUIDE.md`: overview table, decision tree Q1, Assured "When to use" section (now split into two named sub-sections + "Common to both"), comparison table "When to pick" row
- `CLAUDE.md`: sdlc-assured plugin table entry
- `docs/feature-proposals/192-sdlc-assured-agentic-framing.md` + `retrospectives/192-sdlc-assured-agentic-framing.md`

## Test plan

- [x] `local-validation.py --quick` passes (0 errors, 0 warnings)
- [x] `pytest` 599/599 pass
- [x] `check-broken-references.py` — no new broken references introduced
- [x] Docs-only change; no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)