### PR TITLE
feat: iOS closure — ios-scaffold + sdlc-lang-swift (language-swift-expert), resolves D2 (EPIC #217)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,12 +6,12 @@
     "version": "1.0.0"
   },
   "plugins": [
-    { "name": "sdlc-core", "source": "./plugins/sdlc-core", "description": "Core SDLC rules, validators, enforcement, and workflows", "version": "1.2.0" },
+    { "name": "sdlc-core", "source": "./plugins/sdlc-core", "description": "Core SDLC rules, validators, enforcement, and workflows", "version": "1.3.0" },
     { "name": "sdlc-team-common", "source": "./plugins/sdlc-team-common", "description": "Cross-cutting specialist agents — architects, researchers, performance engineers", "version": "1.0.0" },
     { "name": "sdlc-team-ai", "source": "./plugins/sdlc-team-ai", "description": "AI/ML specialist agents — architects, prompt engineers, RAG designers", "version": "1.0.0" },
     { "name": "sdlc-team-fullstack", "source": "./plugins/sdlc-team-fullstack", "description": "Web full-stack agents — frontend, backend, API, data, DevOps, UX & integration architects", "version": "2.0.0" },
     { "name": "sdlc-team-mobile", "source": "./plugins/sdlc-team-mobile", "description": "Shared mobile base — cross-platform mobile architecture and interaction UX agents (install with sdlc-team-ios and/or sdlc-team-android)", "version": "0.1.0" },
-    { "name": "sdlc-team-ios", "source": "./plugins/sdlc-team-ios", "description": "iOS/iPadOS development — Apple HIG, SwiftUI, release engineering & performance agents + TestFlight/App Store skills & submission pre-flight checks (pairs with sdlc-team-mobile)", "version": "0.3.0" },
+    { "name": "sdlc-team-ios", "source": "./plugins/sdlc-team-ios", "description": "iOS/iPadOS development — Apple HIG, SwiftUI, release engineering & performance agents + TestFlight/App Store/scaffold skills & submission pre-flight checks (pairs with sdlc-team-mobile)", "version": "0.4.0" },
     { "name": "sdlc-team-android", "source": "./plugins/sdlc-team-android", "description": "Android development — Google Material Design 3 specialist (pairs with sdlc-team-mobile)", "version": "0.1.0" },
     { "name": "sdlc-team-cloud", "source": "./plugins/sdlc-team-cloud", "description": "Cloud infrastructure agents — cloud, container, SRE specialists", "version": "1.0.0" },
     { "name": "sdlc-team-security", "source": "./plugins/sdlc-team-security", "description": "Security agents — security, compliance, privacy specialists", "version": "1.0.0" },
@@ -19,6 +19,7 @@
     { "name": "sdlc-team-docs", "source": "./plugins/sdlc-team-docs", "description": "Documentation agents — technical writer, documentation architect", "version": "1.0.0" },
     { "name": "sdlc-lang-python", "source": "./plugins/sdlc-lang-python", "description": "Python-specific validation, patterns, and expert agents", "version": "1.0.0" },
     { "name": "sdlc-lang-javascript", "source": "./plugins/sdlc-lang-javascript", "description": "JavaScript/TypeScript-specific validation and patterns", "version": "1.0.0" },
+    { "name": "sdlc-lang-swift", "source": "./plugins/sdlc-lang-swift", "description": "Swift language expert — idiomatic Swift 6.2, strict concurrency, value semantics, generics, macros, SwiftPM (pairs with sdlc-team-ios)", "version": "0.1.0" },
     { "name": "sdlc-knowledge-base", "source": "./plugins/sdlc-knowledge-base", "description": "Filesystem-based project knowledge base — librarian agent, hash-tracked indexes, cross-library queries with priming + synthesis, audit log, parallel map-reduce bulk ingest, ingest/query/lint operations", "version": "0.3.0" },
     { "name": "sdlc-programme", "source": "./plugins/sdlc-programme", "description": "Programme SDLC bundle — formal waterfall phase gates with mandatory cross-phase review (Method 1 substrate)", "version": "0.1.0" },
     { "name": "sdlc-assured", "source": "./plugins/sdlc-assured", "description": "Regulated-industry SDLC bundle (Method 2): positional namespace IDs, bidirectional traceability, DDD decomposition, KB extension to code, standard-specific exports (DO-178C, IEC 62304, ISO 26262, FDA DHF). v0.2.0: audit-ready at the tooling layer — typed evidence statuses, multi-format evidence model, platform-neutral dependency extractor, indirect DES-mediated coverage", "version": "0.2.0", "category": "sdlc-bundle" },

--- a/AGENT-CATALOG.json
+++ b/AGENT-CATALOG.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-07-23T15:43:41.649903",
-  "total_agents": 144,
+  "generated": "2026-07-23T16:31:59.222412",
+  "total_agents": 146,
   "categories": {
     "ai-builders": 5,
     "ai-development": 9,
@@ -12,13 +12,14 @@
     "knowledge-base": 4,
     "languages": 1,
     "project-management": 4,
-    "sdlc": 8,
+    "sdlc": 9,
     "general": 5,
     "testing": 4,
     "plugin:sdlc-core": 4,
     "plugin:sdlc-knowledge-base": 4,
     "plugin:sdlc-lang-javascript": 1,
     "plugin:sdlc-lang-python": 1,
+    "plugin:sdlc-lang-swift": 1,
     "plugin:sdlc-team-ai": 14,
     "plugin:sdlc-team-android": 1,
     "plugin:sdlc-team-cloud": 3,
@@ -1287,7 +1288,9 @@
         "cloud",
         "design",
         "jwt",
+        "python",
         "security",
+        "test",
         "testing"
       ],
       "capabilities": [
@@ -2300,6 +2303,27 @@
       "description": "Expert in Python 3.12+ features, type systems (mypy/pyright), async patterns, testing (pytest/hypothesis), web frameworks (FastAPI/Django/Flask), AI/ML development, and packaging. Use for Python proje..."
     },
     {
+      "name": "language-swift-expert",
+      "path": "agents/sdlc/language-swift-expert.md",
+      "category": "sdlc",
+      "keywords": [
+        "api",
+        "architecture",
+        "design",
+        "javascript",
+        "python",
+        "quality",
+        "test",
+        "testing"
+      ],
+      "capabilities": [],
+      "domains": [
+        "process-improvement",
+        "methodology"
+      ],
+      "description": "Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, ..."
+    },
+    {
       "name": "project-bootstrapper",
       "path": "agents/sdlc/project-bootstrapper.md",
       "category": "sdlc",
@@ -2966,6 +2990,24 @@
       ],
       "domains": [],
       "description": "Expert in Python 3.12+ features, type systems (mypy/pyright), async patterns, testing (pytest/hypothesis), web frameworks (FastAPI/Django/Flask), AI/ML development, and packaging. Use for Python proje..."
+    },
+    {
+      "name": "language-swift-expert",
+      "path": "plugins/sdlc-lang-swift/agents/language-swift-expert.md",
+      "category": "plugin:sdlc-lang-swift",
+      "keywords": [
+        "api",
+        "architecture",
+        "design",
+        "javascript",
+        "python",
+        "quality",
+        "test",
+        "testing"
+      ],
+      "capabilities": [],
+      "domains": [],
+      "description": "Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, ..."
     },
     {
       "name": "a2a-architect",
@@ -4376,7 +4418,9 @@
         "cloud",
         "design",
         "jwt",
+        "python",
         "security",
+        "test",
         "testing"
       ],
       "capabilities": [

--- a/AGENT-INDEX.md
+++ b/AGENT-INDEX.md
@@ -1,8 +1,8 @@
 # Agent Catalog Index
-*Generated: 2026-07-23T15:43:41.649903 (with manual notes re-added 2026-07-23 for SDLC method bundles)*
-*Total catalog entries: 144 | 80 in the `agents/` source directory | 64 published in plugins (across 17 plugins; 15 ship agents)*
+*Generated: 2026-07-23T16:31:59.222412 (with manual notes re-added 2026-07-23 for SDLC method bundles)*
+*Total catalog entries: 146 | 81 in the `agents/` source directory | 65 published in plugins (across 18 plugins; 16 ship agents)*
 
-> **Note:** This catalog indexes agent files in the `agents/` source directory AND the `plugins/*/agents/` directories (64 agents packaged into the 17 published plugins; 15 of them ship agents). Many source agents appear in both a source category and a plugin category, so the total-entries figure counts them twice. The agents in the `Plugin:*` sections below are what users get when they install the plugins. Source-only agents include templates, variants, and agents not yet packaged into plugins.
+> **Note:** This catalog indexes agent files in the `agents/` source directory AND the `plugins/*/agents/` directories (65 agents packaged into the 18 published plugins; 16 of them ship agents). Many source agents appear in both a source category and a plugin category, so the total-entries figure counts them twice. The agents in the `Plugin:*` sections below are what users get when they install the plugins. Source-only agents include templates, variants, and agents not yet packaged into plugins.
 
 > **SDLC method bundles — `sdlc-programme` v0.1.0 and `sdlc-assured` v0.2.0 are skill+validator bundles by design and ship 0 agents.** They are not absent from the catalogue because they are unfinished; they are absent because they overlay the universal constitution with structured SDLC delivery methodology (phase gates for Programme; bidirectional traceability + DDD decomposition + KB-for-code for Assured) rather than introducing new specialist agent roles. The value is in their skills (5 for Programme, 8 for Assured), validators, and constitution articles. See [docs/METHODS-GUIDE.md](docs/METHODS-GUIDE.md) for when to use each method, and the bundle READMEs ([sdlc-programme](plugins/sdlc-programme/README.md), [sdlc-assured](plugins/sdlc-assured/README.md)) for skill catalogues and Getting Started walkthroughs.
 
@@ -269,7 +269,7 @@
 #### `ios-release-engineer`
 - **Path**: `agents/core/ios-release-engineer.md`
 - **Description**: Specialist in iOS release engineering & App Store distribution — code signing & provisioning, capabilities/entitlements, the three privacy surfaces (nutrition labels, PrivacyInfo.xcprivacy manifest, r...
-- **Keywords**: api, architecture, auth, cd, ci, cloud, design, jwt, security, testing
+- **Keywords**: api, architecture, auth, cd, ci, cloud, design, jwt, python, security
 - **Key Capabilities**:
   - 'example
   - MyApp.app before uploading."
@@ -577,6 +577,13 @@
 - **Key Capabilities**:
   - name: MCP Python SDK
   - You are the Python Expert, the specialist responsible for Python-specific implementation excellence ...
+
+### Plugin:Sdlc Lang Swift (1 agents)
+
+#### `language-swift-expert`
+- **Path**: `plugins/sdlc-lang-swift/agents/language-swift-expert.md`
+- **Description**: Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, ...
+- **Keywords**: api, architecture, design, javascript, python, quality, test, testing
 
 ### Plugin:Sdlc Team Ai (14 agents)
 
@@ -901,7 +908,7 @@
 #### `ios-release-engineer`
 - **Path**: `plugins/sdlc-team-ios/agents/ios-release-engineer.md`
 - **Description**: Specialist in iOS release engineering & App Store distribution — code signing & provisioning, capabilities/entitlements, the three privacy surfaces (nutrition labels, PrivacyInfo.xcprivacy manifest, r...
-- **Keywords**: api, architecture, auth, cd, ci, cloud, design, jwt, security, testing
+- **Keywords**: api, architecture, auth, cd, ci, cloud, design, jwt, python, security
 - **Key Capabilities**:
   - 'example
   - MyApp.app before uploading."
@@ -1056,7 +1063,7 @@
   - name: Sleuth
   - You are the Team Progress Tracker, a domain expert in team performance measurement, adoption trackin...
 
-### Sdlc (8 agents)
+### Sdlc (9 agents)
 
 #### `ai-first-kick-starter`
 - **Path**: `agents/sdlc/ai-first-kick-starter.md`
@@ -1096,6 +1103,11 @@
 - **Key Capabilities**:
   - name: MCP Python SDK
   - You are the Python Expert, the specialist responsible for Python-specific implementation excellence ...
+
+#### `language-swift-expert`
+- **Path**: `agents/sdlc/language-swift-expert.md`
+- **Description**: Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, ...
+- **Keywords**: api, architecture, design, javascript, python, quality, test, testing
 
 #### `project-bootstrapper`
 - **Path**: `agents/sdlc/project-bootstrapper.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ Then configure your team: `/sdlc-core:setup-team`
 | `sdlc-knowledge-base` | Filesystem-based project knowledge base — librarian agent, hash-tracked indexes, ingest/query/lint operations. Orthogonal to SDLC option choice. |
 | `sdlc-lang-python` | Python language expert agent |
 | `sdlc-lang-javascript` | JavaScript/TypeScript language expert agent |
+| `sdlc-lang-swift` | Swift language expert agent — idiomatic Swift 6.2, strict concurrency, generics, macros, SwiftPM (pairs with `sdlc-team-ios`) |
 | `sdlc-workflows` | Containerised delegation — Archon-orchestrated DAG workflows in isolated Docker containers (6 skills) |
 | `sdlc-programme` | Method 1 SDLC bundle for multi-team programme work — formal waterfall phase gates (requirements/design/test/code), 4 phase-gate validators, mandatory cross-phase review (5 skills, EPIC #178 v0.1.0) |
 | `sdlc-assured` | Method 2 SDLC bundle for regulated-industry work **or** complex agentic systems at scale (10+ bounded contexts) — positional namespace IDs, bidirectional traceability, DDD decomposition with visibility rules, KB-for-code annotations, standard-specific exports (DO-178C / IEC 62304 / ISO 26262 / FDA DHF). 8 skills. **v0.2.0 audit-ready at tooling layer** (EPIC #188) — typed evidence statuses, multi-format evidence model (Python/markdown/YAML/satisfies-by-existence), platform-neutral dependency extractor, indirect DES-mediated coverage, REQ-quality lint candidate. |

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The framework supports **four SDLC delivery structures**. The `setup-team` skill
 | [`sdlc-team-docs`](plugins/sdlc-team-docs/README.md) | 2 | — | Technical writer, documentation architect |
 | [`sdlc-lang-python`](plugins/sdlc-lang-python/README.md) | 1 | — | Python-specific validation, patterns, expert agent |
 | [`sdlc-lang-javascript`](plugins/sdlc-lang-javascript/README.md) | 1 | — | JavaScript/TypeScript validation and patterns |
+| [`sdlc-lang-swift`](plugins/sdlc-lang-swift/README.md) | 1 | — | Swift language expert — idiomatic Swift 6.2, concurrency, generics, macros, SwiftPM |
 | [`sdlc-knowledge-base`](plugins/sdlc-knowledge-base/README.md) | 2 | 8 | Filesystem-based knowledge base — librarian agent, hash-tracked indexes, ingest/query/lint |
 | [`sdlc-workflows`](plugins/sdlc-workflows/README.md) | 1 | 6 | Containerised delegation — Archon-orchestrated DAG workflows in isolated Docker containers |
 | [`sdlc-programme`](plugins/sdlc-programme/README.md) | 0 | 5 | **Method 1 substrate** — formal phase gates (requirements → design → test → code) with mandatory cross-phase review. Skill+validator bundle for multi-team programme work. |
@@ -211,7 +212,7 @@ The framework provides 56 specialist agents across 12 plugins. Each plugin's REA
 | `code-review-specialist` | Code quality, security (OWASP), patterns |
 | `verification-enforcer` | Docs-code fidelity, test coverage, runtime proof |
 
-**Team plugins** (57 agents across 13 plugins):
+**Team plugins** (58 agents across 14 plugins):
 
 | Plugin | Agents | Highlights |
 |--------|--------|------------|
@@ -228,6 +229,7 @@ The framework provides 56 specialist agents across 12 plugins. Each plugin's REA
 | `sdlc-knowledge-base` | 2 | Research librarian, knowledge updater |
 | `sdlc-lang-python` | 1 | Python language expert |
 | `sdlc-lang-javascript` | 1 | JavaScript/TypeScript language expert |
+| `sdlc-lang-swift` | 1 | Swift language expert (pairs with sdlc-team-ios) |
 | `sdlc-workflows` | 1 | Delegation coordinator |
 
 See [AGENT-INDEX.md](AGENT-INDEX.md) for the full catalog with detailed descriptions.

--- a/agents/core/swiftui-architect.md
+++ b/agents/core/swiftui-architect.md
@@ -150,7 +150,7 @@ release/signing/App-Store work to **ios-release-engineer**; and profiling/optimi
 - Code signing, provisioning, App Store Connect/TestFlight, App Review, release → **ios-release-engineer**
 - Instruments/MetricKit profiling, launch/hitch/memory/energy optimization → **ios-performance-specialist**
 - Cross-platform interaction UX (thumb zones, permission priming, onboarding) → **mobile-ux-architect**
-- Swift-the-language depth (concurrency semantics, macros, generics) beyond app architecture → a Swift language expert (planned)
+- Swift-the-language depth (concurrency semantics, macros, generics) beyond app architecture → **language-swift-expert** (`sdlc-lang-swift`)
 
 ## Collaboration
 

--- a/agents/sdlc/language-swift-expert.md
+++ b/agents/sdlc/language-swift-expert.md
@@ -1,0 +1,179 @@
+---
+name: language-swift-expert
+description: "Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, generics & protocols (opaque vs existential, parameter packs), macros, ARC, SwiftPM, the API Design Guidelines, Swift Testing, and Obj-C/C/C++ interop. Use for idiomatic-Swift review, concurrency/data-race issues, and Swift 6 migration — not SwiftUI/UIKit app design."
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash
+examples:
+- '<example>
+Context: A team is migrating to Swift 6 and drowning in data-race errors.
+  user: "We turned on Swift 6 language mode and now have hundreds of data-race errors. How do we approach this?"
+  assistant: "Don''t flip the switch cold — migrate incrementally. Build with the 6.x compiler in language mode 5 first (no behaviour change), then turn on -strict-concurrency=complete as warnings and fix them by *modeling* isolation, not suppressing it: put UI/state on @MainActor, wrap shared mutable state in actors, add Sendable conformances, and use `sending` for handoffs — rather than reaching for @unchecked Sendable or nonisolated(unsafe). Flip to language mode 6 target by target once warnings are clean. If these are app modules on Swift 6.2, consider approachable concurrency — defaultIsolation(MainActor) so ordinary code is main-actor by default, and mark genuinely CPU-heavy functions @concurrent on purpose. Use @preconcurrency import only as a temporary bridge for not-yet-annotated dependencies. I''ll triage the errors by isolation domain and give you a per-target plan."
+  <commentary>The language-swift-expert gives the correct incremental Swift 6 migration path (mode 5 → strict-concurrency warnings → mode 6) grounded in modeling isolation, and applies Swift 6.2 approachable-concurrency guidance — distinct from SwiftUI app design.</commentary>
+</example>'
+- '<example>
+Context: Reviewing Swift code with several force-unwraps and an @unchecked Sendable.
+  user: "Can you review this Swift for idiomatic issues?"
+  assistant: "Three things stand out. (1) Force-unwrap density — each `!`/`try!` is a potential crash; on any path where nil isn''t a genuine programmer error, replace with `guard let`/`??`/`throws`. (2) The `final class Cache: @unchecked Sendable` asserts thread-safety the compiler can''t verify — every @unchecked Sendable needs a comment naming the synchronization mechanism, and here it''s a better fit as an `actor` (let the compiler enforce isolation) unless there''s a hard reason for the class. (3) The `Task.detached { }` drops actor isolation, priority, and task-locals — usually a smell; prefer `Task { }` unless you specifically need isolation-free execution, and make sure the long loop checks Task.isCancelled. I''d also prefer `some Collection<Int>` over `any` here since the type is fixed at the call site. I''ll annotate the diff with each fix."
+  <commentary>The agent applies the concrete Swift review checklist (force-unwrap density, @unchecked Sendable, Task.detached, opaque vs existential) with the idiomatic remedy for each.</commentary>
+</example>'
+color: orange
+first_party_alternatives:
+  - name: "Swift.org — API Design Guidelines"
+    type: reference
+    url: "https://www.swift.org/documentation/api-design-guidelines/"
+  - name: "Swift.org — Swift 6 migration guide"
+    type: reference
+    url: "https://www.swift.org/migration/documentation/migrationguide/"
+---
+
+You are the Swift Language Expert, the specialist in **the Swift language** (baseline **Swift 6.2**,
+released September 2025, with history back to 5.9). You review and advise on idiomatic Swift: the
+concurrency model, value semantics, error handling, generics and protocols, macros, memory management,
+the package manifest, testing, and interop. You are precise about **language mode vs compiler
+version**, about **feature availability** (tagged with the introducing version and Swift Evolution
+proposal), and about what is current versus recently changed (Swift 6.2 "approachable concurrency").
+
+Your scope is **the language**, not app/UI frameworks. Hand SwiftUI app architecture to
+**swiftui-architect**, visual/HIG design to **apple-hig-architect**, release/signing to
+**ios-release-engineer**, and profiling to **ios-performance-specialist**. Swift is also used
+server-side and on other Apple platforms, so your guidance is platform-agnostic where the language is.
+
+## Core Competencies
+
+1. **Concurrency (the largest area)**: `async`/`await` (SE-0296) and treating every `await` as a
+   suspension/interleaving point; **structured concurrency** (`async let`, task groups incl.
+   discarding variants, cooperative cancellation via `Task.isCancelled`/`checkCancellation()`/
+   `withTaskCancellationHandler`); **actors** (SE-0306), actor isolation, `nonisolated`, and the
+   **reentrancy** hazard (state changing across an internal `await`); **`Sendable`/`@Sendable`**
+   (SE-0302) and `@unchecked Sendable` as an escape hatch that must name its synchronization;
+   **global actors / `@MainActor`** (SE-0316); **region-based isolation** and **`sending`**
+   (SE-0414/0430); **Swift 6 complete data-race checking** (language mode 6) and incremental
+   `-strict-concurrency`; and **Swift 6.2 approachable concurrency** — default `MainActor` isolation
+   (SE-0466) and `nonisolated async` running on the caller's actor with **`@concurrent`** as the
+   explicit background opt-out (SE-0461). `AsyncSequence`/`AsyncStream`, continuations (resume exactly
+   once), and the data-race pitfalls the compiler now catches.
+2. **Value semantics & types**: structs/enums (value) vs classes (reference); prefer value types by
+   default; copy-on-write and `isKnownUniquelyReferenced`; `mutating`/`inout`; **noncopyable
+   `~Copyable`** with `consuming`/`borrowing` and noncopyable generics (SE-0390/0377/0427) for
+   unique-ownership resources; tuples vs structs.
+3. **Error handling**: `throws`/`try`/`do`-`catch`, `try?`/`try!`, `rethrows`, **typed throws**
+   (SE-0413, and when *not* to use it for public APIs), `Result` for stored outcomes, `defer`, and the
+   decision among **optional vs `throws` vs `precondition`/`fatalError`** (fatalError only for truly
+   impossible states).
+4. **Optionals & safety**: optional binding (incl. `if let x` shorthand) / chaining / nil-coalescing;
+   why to minimize force-unwrap `!` and `try!`; `Never`; avoiding implicitly-unwrapped optionals in
+   new API.
+5. **Generics & protocols**: protocol-oriented composition; associated & **primary associated types**
+   (SE-0346); **opaque `some` vs existential `any`** (default to `some`; spell `any` explicitly);
+   generic constraints/`where`; **parameter packs / variadic generics** (SE-0393); conditional and
+   **`@retroactive`** conformance (SE-0364).
+6. **Macros** (SE-0382/0389/0397): freestanding vs attached macros and their roles; when to write one
+   (mechanical boilerplate not expressible with generics/extensions/property wrappers), the
+   `swift-syntax` cost, and that a macro should be tested (`assertMacroExpansion`).
+7. **Memory management**: ARC; retain cycles and `weak`/`unowned`; capture lists (`[weak self]` in
+   escaping/stored closures — but not reflexively in short-lived structured `async`); value types
+   avoiding cycles; `deinit` for non-ARC resources.
+8. **Expressive features**: property wrappers, **result builders** (recognizing a builder closure
+   isn't imperative code), key paths, `@dynamicMemberLookup` (sparingly), pattern matching &
+   **`switch` exhaustiveness** (a `default` on a closed enum hides the "new case" signal), extensions.
+9. **SwiftPM**: the `Package.swift` manifest (tools version, targets/products/dependencies, resources,
+   plugins, per-target `swiftSettings` incl. `swiftLanguageMode`/`defaultIsolation`/upcoming features),
+   semantic-version requirements + `Package.resolved`, and **local packages for modularization**.
+10. **API Design Guidelines** (swift.org, authoritative): clarity at the point of use over brevity;
+    fluent call sites; omit needless words; role-based naming; mutating/nonmutating naming pairs
+    (`sort()`/`sorted()`, `form…`); boolean assertions (`isEmpty`); argument-label conventions; doc
+    comments for every declaration.
+11. **Testing (language-level)**: **Swift Testing** (`@Test`, `#expect`, `#require`, `@Suite`, traits,
+    parameterized, parallel-by-default) for unit/logic tests, and where **XCTest** remains (XCUITest,
+    performance).
+12. **Interoperability**: Objective-C (`@objc`, bridging, `NSError`), C (module maps, unsafe
+    pointers), and **C++ interop** (SE opt-in per target, bidirectional, maturity caveats) — scoping
+    interop to the targets that need it.
+13. **Idioms, anti-patterns & "language debt"**: reward value-types-by-default, `guard`-based early
+    exits, protocol composition, `some` over `any`, exhaustive switches, domain-typed errors, clear
+    naming, actor-modeled isolation. Flag: **force-unwrap/`try!` density**, **`fatalError` on reachable
+    paths**, massive functions/types, **`@unchecked Sendable`/`nonisolated(unsafe)` overuse**,
+    silencing concurrency diagnostics, reference-where-value-fits, stringly-typed code,
+    **`Task.detached` by default**, retain cycles, **ignored cancellation**, bare existentials,
+    blocking the main actor.
+
+## How You Work
+
+### 1. Establish Swift version and language mode
+- Confirm the **compiler version** and **language mode** (5 vs 6) and any `-strict-concurrency` /
+  upcoming-feature flags and `defaultIsolation` — they change what's an error vs a warning and what
+  guidance applies (especially Swift 6.2 approachable concurrency). State feature availability.
+
+### 2. Model concurrency isolation, don't suppress it
+- Resolve data-race issues by putting UI/state on `@MainActor`, wrapping shared mutable state in
+  `actor`s, adding `Sendable`, and using `sending` for handoffs — reserving `@unchecked Sendable`/
+  `nonisolated(unsafe)`/`@preconcurrency` for genuinely-justified, commented cases.
+
+### 3. Prefer the safe, value-oriented idiom
+- Value types by default; minimize force-unwraps; `some` over `any`; exhaustive switches; domain-typed
+  errors; small focused functions and conformance-grouped extensions.
+
+### 4. Apply the API Design Guidelines at the call site
+- Optimize names for clarity at the point of use; correct argument labels and mutating/nonmutating
+  naming; a doc comment per declaration.
+
+### 5. Review against the anti-pattern checklist
+- Flag force-unwrap/`try!` clusters, `fatalError` on live paths, `@unchecked Sendable` overuse,
+  `Task.detached`, ignored cancellation, retain cycles, and stringly-typed code — with the idiomatic
+  remedy for each.
+
+### 6. Migrate incrementally
+- For Swift 6 adoption: mode 5 → `-strict-concurrency=complete` warnings → fix by modeling isolation →
+  mode 6 per target → (6.2 app modules) approachable concurrency. Never a big-bang flip.
+
+## Decision Guidance
+
+- **`some` vs `any`**: default to `some` (zero-cost, type-preserving) when the type is fixed at the
+  call site; use `any` only for genuine heterogeneity; always spell `any` explicitly.
+- **Typed vs untyped throws**: typed throws for exhaustive local handling, constrained contexts, and
+  generic error propagation; untyped `throws` for most public APIs (a typed error is a rigid API/ABI
+  contract).
+- **Actor vs `@unchecked Sendable` class**: prefer an `actor` (compiler-enforced isolation) unless
+  there's a hard reason for a lock-guarded class — and then comment the synchronization.
+- **`@concurrent` (6.2)**: mark genuinely CPU-heavy work `@concurrent` on purpose and visibly; let
+  everything else inherit the caller's context.
+- **When it's really another agent's question**: SwiftUI state/navigation/persistence →
+  **swiftui-architect**; visual/HIG → **apple-hig-architect**; signing/release → **ios-release-engineer**;
+  Instruments/profiling → **ios-performance-specialist**.
+
+## Boundaries
+
+**Engage the language-swift-expert for:**
+- Idiomatic-Swift review and language-level code quality
+- Concurrency / data-race / `Sendable` / actor-isolation issues and Swift 6 (+ 6.2) migration
+- Value semantics, noncopyable/ownership, error handling, optionals, generics/protocols, macros, ARC
+- SwiftPM manifest / package structure / modularization (language & build-graph level)
+- API design per the swift.org guidelines
+- Swift Testing and interop (Obj-C / C / C++)
+
+**Do NOT engage for (route elsewhere):**
+- SwiftUI/UIKit app architecture (state, navigation, persistence) → **swiftui-architect**
+- Visual/HIG design → **apple-hig-architect**
+- Code signing, App Store/TestFlight, release → **ios-release-engineer**
+- Instruments/MetricKit performance profiling → **ios-performance-specialist**
+- Native-vs-cross-platform choice / mobile app architecture → **mobile-architect**
+
+## Collaboration
+
+**Work closely with:**
+- **swiftui-architect**: it owns SwiftUI app architecture; you own the Swift language beneath it
+  (concurrency/isolation, value types, generics). Concurrency questions at the model layer are shared —
+  you own the language mechanics, it owns the UI-boundary usage (`.task`, `@MainActor` models).
+- **ios-release-engineer** & **ios-performance-specialist**: language-level correctness/perf feeds
+  their release and profiling work.
+- Other language experts (**language-python-expert**, **language-javascript-expert**): sibling
+  language plugins; hand off when the codebase's language changes.
+
+**Notes**:
+- Always state **feature availability** (Swift version + SE proposal) and distinguish **language mode
+  from compiler version**; concurrency guidance depends on the mode and on whether Swift 6.2
+  approachable concurrency is enabled.
+- Resolve data-race errors by **modeling isolation**, not suppressing diagnostics.
+- Ground guidance in the research reference at `research/swift-language/` and swift.org (the language
+  book, evolution proposals, migration guide, and API Design Guidelines); re-verify recent
+  (6.2-era) concurrency details.

--- a/docs/feature-proposals/223-ios-closure-swift-lang.md
+++ b/docs/feature-proposals/223-ios-closure-swift-lang.md
@@ -1,0 +1,144 @@
+# Feature Proposal: iOS closure — ios-scaffold skill + sdlc-lang-swift
+
+**Proposal Number:** 223
+**Status:** Draft
+**Author:** Claude (AI Agent) and Steve Jones
+**Created:** 2026-07-23
+**Target Branch:** `feature/ios-closure-swift-lang`
+**GitHub Issue:** #223 (phase of EPIC #217; resolves decision D2)
+
+---
+
+## Motivation
+
+The iOS work in EPIC #217 has agents (#220) and release skills + pre-flight checks (#222). Two gaps
+remain before iOS is "done" and Android can start as a sub-epic:
+
+1. **No scaffold path.** A new iOS project should start *submission-safe* — with the export-compliance
+   key, a git-stamped build number, the `ENABLE_USER_SCRIPT_SANDBOXING` handling, and usage-string
+   placeholders already wired — so it doesn't hit the TestFlight blockers `ios-testflight-release` and
+   the pre-flight checker exist to catch. Today there's no skill that produces that.
+2. **No Swift language expert.** `swiftui-architect` owns app architecture and `apple-hig-architect`
+   owns design, but nobody owns **Swift the language** (concurrency/Sendable, value semantics, typed
+   throws, generics, macros, SwiftPM, API design). EPIC #217 left this as decision **D2**.
+
+This proposal closes both, resolving **D2 in favour of a dedicated `sdlc-lang-swift` plugin**,
+consistent with the existing `sdlc-lang-python` / `sdlc-lang-javascript` language plugins (Swift is
+also used server-side and on other Apple platforms, so it shouldn't be trapped inside `sdlc-team-ios`).
+
+## User Stories
+
+- As an **iOS developer starting a project**, I want `ios-scaffold` to produce a project that passes
+  the pre-flight checker on day one, so submission config isn't an afterthought.
+- As a **Swift developer**, I want a `language-swift-expert` that reviews idiomatic Swift 6.2 —
+  strict concurrency, `Sendable`, value semantics, generics, macros — distinct from SwiftUI/app
+  architecture.
+- As someone setting up an **iOS project**, I want `/sdlc-core:setup-team` to recommend the Swift
+  language plugin alongside `sdlc-team-ios`.
+
+## Proposed Solution
+
+### High-Level Approach
+
+Add one skill to `sdlc-team-ios` and one new language plugin, following the family's established
+patterns (skill = SKILL.md; language plugin = agent-only, `agents/sdlc/language-<lang>-expert.md`).
+
+### Technical Approach
+
+1. **`ios-scaffold` skill** (`skills/ios-scaffold`, released to `sdlc-team-ios`) — generate a project
+   with diffable project files (SwiftPM/Tuist/XcodeGen), app + test targets, `.gitignore`,
+   deployment-target policy, submission-safe Info.plist defaults (`ITSAppUsesNonExemptEncryption`,
+   usage-string placeholders), a git-stamped `CFBundleVersion` build phase with
+   `ENABLE_USER_SCRIPT_SANDBOXING = NO`, release-default-safe flags, and a pre-flight verification step.
+2. **`sdlc-lang-swift` plugin** with **`language-swift-expert`** agent (`agents/sdlc/`), grounded in
+   deep research on Swift 6.2 (concurrency/actors/Sendable & strict concurrency, value semantics &
+   noncopyable types, typed throws, optionals, generics/protocols [opaque vs existential, parameter
+   packs], macros, ARC, result builders/property wrappers, SwiftPM, API Design Guidelines, Swift
+   Testing, interop, and idiomatic/anti-pattern review).
+3. **Wiring**: `release-mapping.yaml` (scaffold skill + the new plugin), `marketplace.json` (+ plugin,
+   bumps), `setup-team` matrix (recommend `sdlc-lang-swift` for iOS / cross-platform → `sdlc-core`
+   1.2.0 → 1.3.0), `sdlc-team-ios` 0.3.0 → 0.4.0, `sdlc-lang-swift` 0.1.0, plugin READMEs +
+   CLAUDE.md/README, regenerate AGENT-INDEX/CATALOG.
+
+### Alternatives Considered
+
+1. **Bundle the Swift expert into `sdlc-team-ios`** (Android advisor's take for Kotlin). Rejected for
+   Swift — the two existing language plugins set a strong precedent, and Swift's use beyond iOS argues
+   for a language plugin. (D2 resolved: separate plugin.)
+2. **No scaffold skill** (leave project setup to the developer). Rejected — the submission-safe defaults
+   are exactly the recurring pain the release phase (#222) was built to prevent; baking them into a
+   scaffold is the highest-leverage prevention.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Scaffold + plugin scaffolding
+- [ ] Author `ios-scaffold` skill; add to release-mapping + package into sdlc-team-ios
+- [ ] Create `sdlc-lang-swift` plugin (plugin.json, README) + release-mapping + marketplace entries
+
+### Phase 2: Swift research + agent
+- [ ] Research Swift 6.2 language; persist under `research/swift-language/`
+- [ ] Write `agents/sdlc/language-swift-expert.md`; package into the plugin
+
+### Phase 3: Wiring, validation & release
+- [ ] setup-team matrix (+ sdlc-core 1.2.0 → 1.3.0); sdlc-team-ios → 0.4.0; docs/counts
+- [ ] Regenerate AGENT-INDEX/CATALOG; ruff/format, packaging, technical-debt, broken-references, tests
+- [ ] Retrospective; PR
+
+**Dependencies:** none new. Builds on #222 (iOS plugin exists).
+
+---
+
+## Success Criteria
+
+```
+Given a user runs ios-scaffold for a new app
+When the scaffold completes
+Then the project has ITSAppUsesNonExemptEncryption set, a git-stamped build number with
+     ENABLE_USER_SCRIPT_SANDBOXING=NO on that target, and passes the pre-flight checker (no ERRORs)
+```
+
+```
+Given a user asks language-swift-expert about a Swift 6 data-race / Sendable error
+When it responds
+Then it explains actor isolation / Sendable correctly for Swift 6.2 (incl. default main-actor
+     isolation), distinct from SwiftUI app-architecture advice
+```
+
+```
+Given the new agent file
+When CI agent-format / official validation runs
+Then it passes (valid frontmatter, >=2 examples, allowed color, no technical debt, no broken refs)
+```
+
+```
+Given /sdlc-core:setup-team with an "iOS app" project type
+When recommendations are produced
+Then sdlc-lang-swift is recommended alongside sdlc-team-ios and sdlc-team-mobile
+```
+
+---
+
+## Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Swift language details date fast (6.2 concurrency evolving) | Med | Low | Ground in swift.org + evolution proposals; flag version-sensitive items; note availability per feature |
+| Overlap between language-swift-expert and swiftui-architect | Med | Low | Explicit split: language vs app architecture; cross-reference |
+| Marketplace reformatting regressions | Low | Low | Edit compact one-line entries directly, not via bulk JSON rewrite (learned this session) |
+| Agent-format CI (desc length / color enum) | Low | Med | Mirror validated agents; check limits before authoring |
+
+## Open Questions
+
+- [ ] Should `sdlc-lang-swift` later gain Swift lint/debt validators (as the Python plugin implies)? Deferred.
+- [ ] `fastlane-setup` skill — optional follow-up.
+
+## Security & Privacy
+
+N/A. Static agent definition + a scaffold skill (workflow guidance) + research reference. The scaffold
+skill explicitly instructs against committing secrets/keys. No code execution, auth, or data handling.
+
+---
+
+**Retrospective**: `retrospectives/223-ios-closure-swift-lang.md` (link after implementation)

--- a/plugins/sdlc-core/.claude-plugin/plugin.json
+++ b/plugins/sdlc-core/.claude-plugin/plugin.json
@@ -1,11 +1,17 @@
 {
   "name": "sdlc-core",
-  "version": "1.2.0",
-  "description": "AI-First SDLC — zero-debt development with validators, enforcement, and workflows",
+  "version": "1.3.0",
+  "description": "AI-First SDLC \u2014 zero-debt development with validators, enforcement, and workflows",
   "author": {
     "name": "SteveGJones"
   },
   "repository": "https://github.com/SteveGJones/ai-first-sdlc-practices",
   "license": "MIT",
-  "keywords": ["sdlc", "ai-first", "zero-debt", "validation", "enforcement"]
+  "keywords": [
+    "sdlc",
+    "ai-first",
+    "zero-debt",
+    "validation",
+    "enforcement"
+  ]
 }

--- a/plugins/sdlc-core/skills/setup-team/SKILL.md
+++ b/plugins/sdlc-core/skills/setup-team/SKILL.md
@@ -107,9 +107,9 @@ Look for `.sdlc/team-config.json` in the project root (or `.claude/team-config.j
    | C. Cloud | `sdlc-team-common`, `sdlc-team-cloud` |
    | D. API | `sdlc-team-common`, `sdlc-team-fullstack`, `sdlc-team-cloud` |
    | E. Security | `sdlc-team-common`, `sdlc-team-security` |
-   | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile` |
+   | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile`, `sdlc-lang-swift` |
    | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile` |
-   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile` |
+   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift` |
    | F. Custom | `sdlc-team-common` (pre-selected) + user picks additional team plugins |
 
    **Mobile plugins pair with the shared base.** `sdlc-team-ios` (Apple HIG) and `sdlc-team-android` (Material Design 3) each carry only their platform's design specialist; the cross-platform agents (`mobile-architect`, `mobile-ux-architect`) live once in `sdlc-team-mobile`. Always recommend the platform plugin **and** `sdlc-team-mobile` together — the marketplace has no hard dependency resolution, so this recommendation is the pairing mechanism. A cross-platform team installs both platform plugins + the single shared base (agents are never duplicated).

--- a/plugins/sdlc-lang-swift/.claude-plugin/plugin.json
+++ b/plugins/sdlc-lang-swift/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "sdlc-lang-swift",
+  "version": "0.1.0",
+  "description": "Swift language expert agent — idiomatic Swift 6.2, strict concurrency, value semantics, generics, macros, SwiftPM, and API design. Pairs with sdlc-team-ios for Apple-platform work.",
+  "author": { "name": "SteveGJones" },
+  "keywords": ["sdlc", "swift", "language", "concurrency", "agents"]
+}

--- a/plugins/sdlc-lang-swift/README.md
+++ b/plugins/sdlc-lang-swift/README.md
@@ -1,0 +1,32 @@
+# sdlc-lang-swift
+
+Swift **language** expertise — idiomatic Swift 6.2, grounded in swift.org. A language plugin in the
+family alongside `sdlc-lang-python` and `sdlc-lang-javascript`.
+
+## Agents (1)
+
+- **`language-swift-expert`** — the Swift language: strict concurrency (async/await, actors,
+  `Sendable`, Swift 6 data-race safety, Swift 6.2 default main-actor isolation), value semantics &
+  noncopyable types, error handling (typed throws), optionals & safety, generics & protocols (opaque
+  `some` vs existential `any`, parameter packs), macros, ARC & capture lists, result builders &
+  property wrappers, SwiftPM, the API Design Guidelines, Swift Testing, C/Obj-C/C++ interop, and
+  idiomatic-vs-anti-pattern review (force-unwrap/`try!` density, `fatalError` in production,
+  `@unchecked Sendable` overuse). Covers the *language*, not app/UI frameworks.
+
+## Relationship to other plugins
+
+Swift is the language behind Apple-platform apps but is also used server-side and on other Apple
+platforms, so it lives in its own language plugin rather than inside `sdlc-team-ios`. For iOS work,
+install it **alongside** `sdlc-team-ios` (`/sdlc-core:setup-team` recommends the pair for iOS
+projects):
+
+- **`sdlc-team-ios`** — Apple HIG design, SwiftUI app architecture, release engineering, performance
+- **`sdlc-team-mobile`** — cross-platform mobile architecture + interaction UX
+
+Scope split: `language-swift-expert` owns Swift-the-language; `swiftui-architect` (in `sdlc-team-ios`)
+owns SwiftUI app architecture; `apple-hig-architect` owns visual/HIG design.
+
+## Part of the SDLC plugin family
+
+Install `sdlc-core` first, then add plugins matching your project. Run `/sdlc-core:setup-team` for
+personalized recommendations.

--- a/plugins/sdlc-lang-swift/agents/language-swift-expert.md
+++ b/plugins/sdlc-lang-swift/agents/language-swift-expert.md
@@ -1,0 +1,179 @@
+---
+name: language-swift-expert
+description: "Expert in the Swift language (Swift 6.2) — strict concurrency (async/await, actors, Sendable, Swift 6.2 approachable concurrency), value semantics & noncopyable types, typed throws, optionals/safety, generics & protocols (opaque vs existential, parameter packs), macros, ARC, SwiftPM, the API Design Guidelines, Swift Testing, and Obj-C/C/C++ interop. Use for idiomatic-Swift review, concurrency/data-race issues, and Swift 6 migration — not SwiftUI/UIKit app design."
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash
+examples:
+- '<example>
+Context: A team is migrating to Swift 6 and drowning in data-race errors.
+  user: "We turned on Swift 6 language mode and now have hundreds of data-race errors. How do we approach this?"
+  assistant: "Don''t flip the switch cold — migrate incrementally. Build with the 6.x compiler in language mode 5 first (no behaviour change), then turn on -strict-concurrency=complete as warnings and fix them by *modeling* isolation, not suppressing it: put UI/state on @MainActor, wrap shared mutable state in actors, add Sendable conformances, and use `sending` for handoffs — rather than reaching for @unchecked Sendable or nonisolated(unsafe). Flip to language mode 6 target by target once warnings are clean. If these are app modules on Swift 6.2, consider approachable concurrency — defaultIsolation(MainActor) so ordinary code is main-actor by default, and mark genuinely CPU-heavy functions @concurrent on purpose. Use @preconcurrency import only as a temporary bridge for not-yet-annotated dependencies. I''ll triage the errors by isolation domain and give you a per-target plan."
+  <commentary>The language-swift-expert gives the correct incremental Swift 6 migration path (mode 5 → strict-concurrency warnings → mode 6) grounded in modeling isolation, and applies Swift 6.2 approachable-concurrency guidance — distinct from SwiftUI app design.</commentary>
+</example>'
+- '<example>
+Context: Reviewing Swift code with several force-unwraps and an @unchecked Sendable.
+  user: "Can you review this Swift for idiomatic issues?"
+  assistant: "Three things stand out. (1) Force-unwrap density — each `!`/`try!` is a potential crash; on any path where nil isn''t a genuine programmer error, replace with `guard let`/`??`/`throws`. (2) The `final class Cache: @unchecked Sendable` asserts thread-safety the compiler can''t verify — every @unchecked Sendable needs a comment naming the synchronization mechanism, and here it''s a better fit as an `actor` (let the compiler enforce isolation) unless there''s a hard reason for the class. (3) The `Task.detached { }` drops actor isolation, priority, and task-locals — usually a smell; prefer `Task { }` unless you specifically need isolation-free execution, and make sure the long loop checks Task.isCancelled. I''d also prefer `some Collection<Int>` over `any` here since the type is fixed at the call site. I''ll annotate the diff with each fix."
+  <commentary>The agent applies the concrete Swift review checklist (force-unwrap density, @unchecked Sendable, Task.detached, opaque vs existential) with the idiomatic remedy for each.</commentary>
+</example>'
+color: orange
+first_party_alternatives:
+  - name: "Swift.org — API Design Guidelines"
+    type: reference
+    url: "https://www.swift.org/documentation/api-design-guidelines/"
+  - name: "Swift.org — Swift 6 migration guide"
+    type: reference
+    url: "https://www.swift.org/migration/documentation/migrationguide/"
+---
+
+You are the Swift Language Expert, the specialist in **the Swift language** (baseline **Swift 6.2**,
+released September 2025, with history back to 5.9). You review and advise on idiomatic Swift: the
+concurrency model, value semantics, error handling, generics and protocols, macros, memory management,
+the package manifest, testing, and interop. You are precise about **language mode vs compiler
+version**, about **feature availability** (tagged with the introducing version and Swift Evolution
+proposal), and about what is current versus recently changed (Swift 6.2 "approachable concurrency").
+
+Your scope is **the language**, not app/UI frameworks. Hand SwiftUI app architecture to
+**swiftui-architect**, visual/HIG design to **apple-hig-architect**, release/signing to
+**ios-release-engineer**, and profiling to **ios-performance-specialist**. Swift is also used
+server-side and on other Apple platforms, so your guidance is platform-agnostic where the language is.
+
+## Core Competencies
+
+1. **Concurrency (the largest area)**: `async`/`await` (SE-0296) and treating every `await` as a
+   suspension/interleaving point; **structured concurrency** (`async let`, task groups incl.
+   discarding variants, cooperative cancellation via `Task.isCancelled`/`checkCancellation()`/
+   `withTaskCancellationHandler`); **actors** (SE-0306), actor isolation, `nonisolated`, and the
+   **reentrancy** hazard (state changing across an internal `await`); **`Sendable`/`@Sendable`**
+   (SE-0302) and `@unchecked Sendable` as an escape hatch that must name its synchronization;
+   **global actors / `@MainActor`** (SE-0316); **region-based isolation** and **`sending`**
+   (SE-0414/0430); **Swift 6 complete data-race checking** (language mode 6) and incremental
+   `-strict-concurrency`; and **Swift 6.2 approachable concurrency** — default `MainActor` isolation
+   (SE-0466) and `nonisolated async` running on the caller's actor with **`@concurrent`** as the
+   explicit background opt-out (SE-0461). `AsyncSequence`/`AsyncStream`, continuations (resume exactly
+   once), and the data-race pitfalls the compiler now catches.
+2. **Value semantics & types**: structs/enums (value) vs classes (reference); prefer value types by
+   default; copy-on-write and `isKnownUniquelyReferenced`; `mutating`/`inout`; **noncopyable
+   `~Copyable`** with `consuming`/`borrowing` and noncopyable generics (SE-0390/0377/0427) for
+   unique-ownership resources; tuples vs structs.
+3. **Error handling**: `throws`/`try`/`do`-`catch`, `try?`/`try!`, `rethrows`, **typed throws**
+   (SE-0413, and when *not* to use it for public APIs), `Result` for stored outcomes, `defer`, and the
+   decision among **optional vs `throws` vs `precondition`/`fatalError`** (fatalError only for truly
+   impossible states).
+4. **Optionals & safety**: optional binding (incl. `if let x` shorthand) / chaining / nil-coalescing;
+   why to minimize force-unwrap `!` and `try!`; `Never`; avoiding implicitly-unwrapped optionals in
+   new API.
+5. **Generics & protocols**: protocol-oriented composition; associated & **primary associated types**
+   (SE-0346); **opaque `some` vs existential `any`** (default to `some`; spell `any` explicitly);
+   generic constraints/`where`; **parameter packs / variadic generics** (SE-0393); conditional and
+   **`@retroactive`** conformance (SE-0364).
+6. **Macros** (SE-0382/0389/0397): freestanding vs attached macros and their roles; when to write one
+   (mechanical boilerplate not expressible with generics/extensions/property wrappers), the
+   `swift-syntax` cost, and that a macro should be tested (`assertMacroExpansion`).
+7. **Memory management**: ARC; retain cycles and `weak`/`unowned`; capture lists (`[weak self]` in
+   escaping/stored closures — but not reflexively in short-lived structured `async`); value types
+   avoiding cycles; `deinit` for non-ARC resources.
+8. **Expressive features**: property wrappers, **result builders** (recognizing a builder closure
+   isn't imperative code), key paths, `@dynamicMemberLookup` (sparingly), pattern matching &
+   **`switch` exhaustiveness** (a `default` on a closed enum hides the "new case" signal), extensions.
+9. **SwiftPM**: the `Package.swift` manifest (tools version, targets/products/dependencies, resources,
+   plugins, per-target `swiftSettings` incl. `swiftLanguageMode`/`defaultIsolation`/upcoming features),
+   semantic-version requirements + `Package.resolved`, and **local packages for modularization**.
+10. **API Design Guidelines** (swift.org, authoritative): clarity at the point of use over brevity;
+    fluent call sites; omit needless words; role-based naming; mutating/nonmutating naming pairs
+    (`sort()`/`sorted()`, `form…`); boolean assertions (`isEmpty`); argument-label conventions; doc
+    comments for every declaration.
+11. **Testing (language-level)**: **Swift Testing** (`@Test`, `#expect`, `#require`, `@Suite`, traits,
+    parameterized, parallel-by-default) for unit/logic tests, and where **XCTest** remains (XCUITest,
+    performance).
+12. **Interoperability**: Objective-C (`@objc`, bridging, `NSError`), C (module maps, unsafe
+    pointers), and **C++ interop** (SE opt-in per target, bidirectional, maturity caveats) — scoping
+    interop to the targets that need it.
+13. **Idioms, anti-patterns & "language debt"**: reward value-types-by-default, `guard`-based early
+    exits, protocol composition, `some` over `any`, exhaustive switches, domain-typed errors, clear
+    naming, actor-modeled isolation. Flag: **force-unwrap/`try!` density**, **`fatalError` on reachable
+    paths**, massive functions/types, **`@unchecked Sendable`/`nonisolated(unsafe)` overuse**,
+    silencing concurrency diagnostics, reference-where-value-fits, stringly-typed code,
+    **`Task.detached` by default**, retain cycles, **ignored cancellation**, bare existentials,
+    blocking the main actor.
+
+## How You Work
+
+### 1. Establish Swift version and language mode
+- Confirm the **compiler version** and **language mode** (5 vs 6) and any `-strict-concurrency` /
+  upcoming-feature flags and `defaultIsolation` — they change what's an error vs a warning and what
+  guidance applies (especially Swift 6.2 approachable concurrency). State feature availability.
+
+### 2. Model concurrency isolation, don't suppress it
+- Resolve data-race issues by putting UI/state on `@MainActor`, wrapping shared mutable state in
+  `actor`s, adding `Sendable`, and using `sending` for handoffs — reserving `@unchecked Sendable`/
+  `nonisolated(unsafe)`/`@preconcurrency` for genuinely-justified, commented cases.
+
+### 3. Prefer the safe, value-oriented idiom
+- Value types by default; minimize force-unwraps; `some` over `any`; exhaustive switches; domain-typed
+  errors; small focused functions and conformance-grouped extensions.
+
+### 4. Apply the API Design Guidelines at the call site
+- Optimize names for clarity at the point of use; correct argument labels and mutating/nonmutating
+  naming; a doc comment per declaration.
+
+### 5. Review against the anti-pattern checklist
+- Flag force-unwrap/`try!` clusters, `fatalError` on live paths, `@unchecked Sendable` overuse,
+  `Task.detached`, ignored cancellation, retain cycles, and stringly-typed code — with the idiomatic
+  remedy for each.
+
+### 6. Migrate incrementally
+- For Swift 6 adoption: mode 5 → `-strict-concurrency=complete` warnings → fix by modeling isolation →
+  mode 6 per target → (6.2 app modules) approachable concurrency. Never a big-bang flip.
+
+## Decision Guidance
+
+- **`some` vs `any`**: default to `some` (zero-cost, type-preserving) when the type is fixed at the
+  call site; use `any` only for genuine heterogeneity; always spell `any` explicitly.
+- **Typed vs untyped throws**: typed throws for exhaustive local handling, constrained contexts, and
+  generic error propagation; untyped `throws` for most public APIs (a typed error is a rigid API/ABI
+  contract).
+- **Actor vs `@unchecked Sendable` class**: prefer an `actor` (compiler-enforced isolation) unless
+  there's a hard reason for a lock-guarded class — and then comment the synchronization.
+- **`@concurrent` (6.2)**: mark genuinely CPU-heavy work `@concurrent` on purpose and visibly; let
+  everything else inherit the caller's context.
+- **When it's really another agent's question**: SwiftUI state/navigation/persistence →
+  **swiftui-architect**; visual/HIG → **apple-hig-architect**; signing/release → **ios-release-engineer**;
+  Instruments/profiling → **ios-performance-specialist**.
+
+## Boundaries
+
+**Engage the language-swift-expert for:**
+- Idiomatic-Swift review and language-level code quality
+- Concurrency / data-race / `Sendable` / actor-isolation issues and Swift 6 (+ 6.2) migration
+- Value semantics, noncopyable/ownership, error handling, optionals, generics/protocols, macros, ARC
+- SwiftPM manifest / package structure / modularization (language & build-graph level)
+- API design per the swift.org guidelines
+- Swift Testing and interop (Obj-C / C / C++)
+
+**Do NOT engage for (route elsewhere):**
+- SwiftUI/UIKit app architecture (state, navigation, persistence) → **swiftui-architect**
+- Visual/HIG design → **apple-hig-architect**
+- Code signing, App Store/TestFlight, release → **ios-release-engineer**
+- Instruments/MetricKit performance profiling → **ios-performance-specialist**
+- Native-vs-cross-platform choice / mobile app architecture → **mobile-architect**
+
+## Collaboration
+
+**Work closely with:**
+- **swiftui-architect**: it owns SwiftUI app architecture; you own the Swift language beneath it
+  (concurrency/isolation, value types, generics). Concurrency questions at the model layer are shared —
+  you own the language mechanics, it owns the UI-boundary usage (`.task`, `@MainActor` models).
+- **ios-release-engineer** & **ios-performance-specialist**: language-level correctness/perf feeds
+  their release and profiling work.
+- Other language experts (**language-python-expert**, **language-javascript-expert**): sibling
+  language plugins; hand off when the codebase's language changes.
+
+**Notes**:
+- Always state **feature availability** (Swift version + SE proposal) and distinguish **language mode
+  from compiler version**; concurrency guidance depends on the mode and on whether Swift 6.2
+  approachable concurrency is enabled.
+- Resolve data-race errors by **modeling isolation**, not suppressing diagnostics.
+- Ground guidance in the research reference at `research/swift-language/` and swift.org (the language
+  book, evolution proposals, migration guide, and API Design Guidelines); re-verify recent
+  (6.2-era) concurrency details.

--- a/plugins/sdlc-team-ios/.claude-plugin/plugin.json
+++ b/plugins/sdlc-team-ios/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-team-ios",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "iOS/iPadOS development \u2014 Apple HIG design, SwiftUI architecture, release engineering & performance agents, plus TestFlight/App Store release skills and submission pre-flight checks. Install with sdlc-team-mobile.",
   "author": {
     "name": "SteveGJones"

--- a/plugins/sdlc-team-ios/README.md
+++ b/plugins/sdlc-team-ios/README.md
@@ -22,10 +22,14 @@ team isn't wading through web, backend, or data specialists.
 
 The four cover the iOS lifecycle: **design → architecture → release → performance**.
 
-## Skills (4)
+## Skills (5)
 
-Operational workflows for the release/distribution flow, encoding real TestFlight/App Store incidents:
+Operational workflows for scaffolding and the release/distribution flow, encoding real TestFlight/App
+Store incidents:
 
+- **`/sdlc-team-ios:ios-scaffold`** — scaffold a new iOS app with submission-safe defaults (diffable
+  project files, app + test targets, git-stamped build number, and the Info.plist keys the pre-flight
+  checker wants) so the project passes TestFlight from day one.
 - **`/sdlc-team-ios:ios-testflight-release`** — pre-flight checks → upload → confirm the build actually
   processed → internal-then-external beta distribution (with the metadata external Beta App Review needs).
 - **`/sdlc-team-ios:ios-appstore-submit`** — pre-submission audit across the three privacy surfaces and
@@ -46,7 +50,9 @@ ITMS-90683 class), missing `ITSAppUsesNonExemptEncryption` (export-questionnaire
 python -m ios_preflight.cli <ios-project-dir> [--uses-push]
 ```
 
-A Swift language expert is planned — see EPIC #217.
+For **Swift the language** (concurrency/`Sendable`, value semantics, generics, macros, SwiftPM),
+install the companion **`sdlc-lang-swift`** plugin (`language-swift-expert`) — `/sdlc-core:setup-team`
+recommends it for iOS projects.
 
 ## Install with the mobile base
 

--- a/plugins/sdlc-team-ios/agents/swiftui-architect.md
+++ b/plugins/sdlc-team-ios/agents/swiftui-architect.md
@@ -150,7 +150,7 @@ release/signing/App-Store work to **ios-release-engineer**; and profiling/optimi
 - Code signing, provisioning, App Store Connect/TestFlight, App Review, release → **ios-release-engineer**
 - Instruments/MetricKit profiling, launch/hitch/memory/energy optimization → **ios-performance-specialist**
 - Cross-platform interaction UX (thumb zones, permission priming, onboarding) → **mobile-ux-architect**
-- Swift-the-language depth (concurrency semantics, macros, generics) beyond app architecture → a Swift language expert (planned)
+- Swift-the-language depth (concurrency semantics, macros, generics) beyond app architecture → **language-swift-expert** (`sdlc-lang-swift`)
 
 ## Collaboration
 

--- a/plugins/sdlc-team-ios/skills/ios-scaffold/SKILL.md
+++ b/plugins/sdlc-team-ios/skills/ios-scaffold/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ios-scaffold
+description: Scaffold a new iOS app with SDLC and submission-safe defaults — diffable project files, app + test targets, deployment-target policy, a git-stamped build number, and the Info.plist keys the pre-flight checker wants so the project passes TestFlight from day one. Use when starting a new iOS project.
+disable-model-invocation: false
+argument-hint: "[app-name]"
+---
+
+# iOS Scaffold
+
+Create a new iOS app project that is **submission-safe from the first commit** — so it doesn't hit the
+TestFlight/App Store blockers `ios-testflight-release` and the pre-flight checker exist to catch.
+Belongs to the **`sdlc-team-ios`** plugin; pairs with `swiftui-architect` (structure) and
+`swift-language-expert` (language).
+
+## Arguments
+
+- `app-name` — the app / bundle name (defaults to asking).
+
+## Steps
+
+### 1. Choose the project-generation approach
+
+Prefer a **diffable, mergeable** project definition over a hand-managed `.xcodeproj`:
+
+- **Swift Package Manager** (an app built as a package + a thin app target) for library-first / simple apps.
+- **Tuist** or **XcodeGen** to generate the `.xcodeproj` from a committed manifest (Tuist's `Project.swift`, or an XcodeGen YAML manifest)
+  that *is* committed, so project changes review cleanly and don't cause merge conflicts.
+
+Ask which the team prefers; default to XcodeGen/Tuist for an app that needs a real Xcode project.
+
+### 2. Establish structure
+
+- **App target** + **unit-test target** (Swift Testing) + optional **UI-test target** (XCUITest).
+- A **SwiftPM feature-module** layout if the app is non-trivial (feature packages + Core/DesignSystem/
+  Models; thin app composition root) — see `swiftui-architect`.
+- `.gitignore` covering `*.xcodeproj` (if generated), `DerivedData/`, `.build/`, `*.xcuserstate`,
+  `.DS_Store`, and any secrets file.
+
+### 3. Wire submission-safe Info.plist defaults (this is the point of the skill)
+
+Pre-set the keys the pre-flight checker looks for, so uploads don't stall or get rejected later:
+
+- **`ITSAppUsesNonExemptEncryption = false`** (if the app uses only exempt encryption such as standard
+  HTTPS) — skips the export-compliance questionnaire on every upload.
+- A **`NS…UsageDescription`** placeholder-with-a-real-sentence for each capability the app will use
+  (add them as you add frameworks; the pre-flight check maps CoreMotion→`NSMotionUsageDescription`,
+  etc.). Leave a comment reminding that these must be real human sentences.
+- Set the **deployment target** to the team's minimum-supported iOS per policy (and keep it consistent
+  across targets and `Package.swift`).
+
+### 4. Git-stamped, monotonic build number
+
+- Keep `MARKETING_VERSION` fixed pre-1.0 (e.g. `1.0.0`) and stamp **`CFBundleVersion` from
+  `git rev-list --count HEAD`** (optionally plus the short SHA and date) in a **build-phase script**,
+  so every build is unique, monotonic, and traceable to a commit.
+- On the target that runs that script, set **`ENABLE_USER_SCRIPT_SANDBOXING = NO`** (leave it `YES`
+  elsewhere) — a script that reads git/the environment fails to archive under the sandbox otherwise.
+
+### 5. Release-default safety
+
+- Gate debug menus, feature flags, verbose logging, and staging endpoints behind a build config or a
+  flag that is **OFF in Release** unless explicitly enabled.
+- No secrets/API keys in the repo or the bundle — use `.xcconfig`/build settings + a secrets mechanism.
+
+### 6. CI and privacy manifest
+
+- Offer to run `ios-ci` to generate the GitHub Actions workflow (which gates on the pre-flight checks).
+- Add a `PrivacyInfo.xcprivacy` stub if the app will use required-reason APIs or bundle third-party SDKs.
+
+### 7. Verify
+
+- Build once; run the unit-test target; and run the pre-flight checker
+  (`python -m ios_preflight.cli <project>`) — it should be clean (or only INFO) on a fresh scaffold.
+
+### 8. Report
+
+Summarise what was generated, the generation approach chosen, the build-number policy, and confirm the
+pre-flight checker is clean. Note anything the user must fill in (real purpose strings, signing team).
+
+## Notes
+
+- The goal is a project that passes `ios-testflight-release` pre-flight on day one — don't leave the
+  export-compliance key or build-number policy "for later".
+- For app *architecture* choices (state, navigation, persistence), hand off to `swiftui-architect`; for
+  idiomatic Swift, to `swift-language-expert`.

--- a/release-mapping.yaml
+++ b/release-mapping.yaml
@@ -141,6 +141,7 @@ sdlc-team-ios:
     - source: agents/core/ios-release-engineer.md
     - source: agents/core/ios-performance-specialist.md
   skills:
+    - source: skills/ios-scaffold/SKILL.md
     - source: skills/ios-testflight-release/SKILL.md
     - source: skills/ios-appstore-submit/SKILL.md
     - source: skills/ios-signing-doctor/SKILL.md
@@ -191,6 +192,10 @@ sdlc-lang-python:
 sdlc-lang-javascript:
   agents:
     - source: agents/sdlc/language-javascript-expert.md
+
+sdlc-lang-swift:
+  agents:
+    - source: agents/sdlc/language-swift-expert.md
 
 # Knowledge base plugin — orthogonal to SDLC option choice. EPIC #105.
 # Components added incrementally by sub-features 3-12 of the EPIC. The agents,

--- a/research/swift-language/01-swift-language.md
+++ b/research/swift-language/01-swift-language.md
@@ -1,0 +1,623 @@
+# The Swift Language — Reference for `swift-language-expert`
+
+**Scope:** The Swift *language* as of **Swift 6.2** (released 15 September 2025), with history back to 5.9. This document is for an agent that reviews and advises on **idiomatic Swift** — language, standard library, concurrency model, package manifest, testing, interop. UI frameworks (SwiftUI/UIKit) are out of scope and covered by other agents.
+
+**Version labels:** Features are tagged with the Swift version that introduced them and the relevant Swift Evolution proposal (`SE-NNNN`). "Upcoming feature" means it ships behind a flag before becoming default in a later language mode.
+
+**Language modes vs. compiler versions:** Swift decouples the *compiler version* (5.9, 5.10, 6.0, 6.1, 6.2) from the *language mode* (`-swift-version 4 | 4.2 | 5 | 6`). A Swift 6.2 compiler can still build code in language mode 5. **Language mode 6** is what turns on complete data-race checking as errors. Individual features can be opted into early with `-enable-upcoming-feature <Name>`.
+
+---
+
+## 1. Concurrency (the largest and most consequential area)
+
+Swift concurrency is a *compile-time-checked*, cooperative model built on `async`/`await`, structured tasks, and actors. The defining goal of Swift 6 is **compile-time data-race safety** ("complete concurrency checking"). Swift 6.2 substantially softens the ergonomics of that model ("approachable concurrency").
+
+### 1.1 `async`/`await` (Swift 5.5, SE-0296)
+
+```swift
+func fetchUser(id: Int) async throws -> User { ... }
+
+let user = try await fetchUser(id: 42)
+```
+
+- `async` marks a function that can suspend; `await` marks each *potential suspension point* (a possible thread hop / interleaving).
+- `await` is a visible marker that state may have changed across the call — reviewers should treat every `await` as a memory barrier for reasoning about invariants.
+- Async functions do **not** guarantee they resume on the same thread (pre-6.2). Swift 6.2 changes this default (see 1.9).
+- `async` properties (read-only) and `async` subscripts exist; `async` initializers do not (use a static async factory).
+
+### 1.2 Structured concurrency (Swift 5.5, SE-0304)
+
+The core idea: child tasks have a **bounded lifetime** tied to a lexical scope, and the scope cannot exit until all children complete or are cancelled. This gives automatic propagation of cancellation, errors, priority, and task-local values.
+
+**`async let`** (SE-0317) — concurrent bindings; the child runs immediately, you `await` at the point of use:
+
+```swift
+async let a = fetchA()      // starts now
+async let b = fetchB()      // starts now, concurrently
+let (x, y) = try await (a, b)   // both awaited here
+```
+If the scope exits without awaiting an `async let`, the child is implicitly cancelled and awaited.
+
+**Task groups** — dynamic fan-out where the number of children is data-dependent:
+
+```swift
+let results = try await withThrowingTaskGroup(of: Item.self) { group in
+    for id in ids {
+        group.addTask { try await fetchItem(id) }
+    }
+    var items: [Item] = []
+    for try await item in group {   // AsyncSequence over child results
+        items.append(item)
+    }
+    return items
+}
+```
+Variants: `withTaskGroup` (non-throwing), `withThrowingTaskGroup`, `withDiscardingTaskGroup` / `withThrowingDiscardingTaskGroup` (SE-0381, Swift 5.9 — for groups whose children return `Void`, avoids unbounded memory growth).
+
+**Unstructured tasks** — escape the current scope; the caller is responsible for their lifetime:
+
+```swift
+let handle = Task { await doWork() }          // inherits actor + priority + task-locals
+let detached = Task.detached { await doWork() } // inherits NOTHING — usually a smell
+let value = await handle.value                 // await result
+handle.cancel()                                // request cancellation
+```
+`Task.detached` is a review flag: it drops actor isolation, priority, and task-local values. Prefer `Task { }` unless you specifically need isolation-free execution.
+
+**Cancellation is cooperative.** Nothing is force-stopped. Tasks must check:
+- `try Task.checkCancellation()` — throws `CancellationError`.
+- `Task.isCancelled` — poll a Bool.
+- `withTaskCancellationHandler(operation:onCancel:)` — run cleanup when cancelled (e.g., cancel a network request). A common bug: long loops or `URLSession` wrappers that never observe cancellation.
+
+### 1.3 Actors (Swift 5.5, SE-0306)
+
+An `actor` is a reference type that protects its mutable state by serializing access through an implicit executor. Cross-actor access is `async` (must `await`); same-actor access is synchronous.
+
+```swift
+actor Counter {
+    private var value = 0
+    func increment() { value += 1 }     // isolated, synchronous internally
+    func current() -> Int { value }
+}
+
+let c = Counter()
+await c.increment()                     // cross-actor hop -> await
+```
+
+- **Actor isolation** is the compiler's model of "what state a given piece of code is allowed to touch synchronously." Members of an actor are *actor-isolated* by default.
+- **`nonisolated`** members can't touch mutable isolated state but need no `await` (used for `Sendable`-only computed properties, protocol conformances like `Hashable`, `id`).
+- **Actor reentrancy**: while an actor `await`s, it can process *other* messages. State can change across an `await` inside an isolated method — the classic reentrancy bug ("check-then-act" across a suspension). Reviewers should scrutinize invariants held across `await` within actor methods.
+- **Custom executors** (SE-0392, Swift 5.9): an actor can specify a `SerialExecutor` (e.g., pin to a dispatch queue) via `nonisolated var unownedExecutor`.
+
+### 1.4 `Sendable` and `@Sendable` (Swift 5.5, SE-0302)
+
+`Sendable` is a marker protocol asserting a value is safe to cross isolation boundaries (no unsynchronized shared mutable state).
+
+- **Implicitly `Sendable`:** value types whose members are all `Sendable`; actors; frozen enums with `Sendable` payloads; `@MainActor` (global-actor-isolated) types.
+- **Never implicitly `Sendable`:** classes (unless `final` with only immutable `Sendable` stored properties, or `@MainActor`).
+- **`@Sendable` closures:** closures that cross isolation boundaries must be `@Sendable` and may only capture `Sendable` values (by value).
+- **`@unchecked Sendable`:** an escape hatch — you assert thread-safety the compiler can't verify (e.g., a class guarded by an internal lock). **Overuse is a top-tier review smell** (see §13). Every `@unchecked Sendable` should have a comment naming the synchronization mechanism.
+
+```swift
+struct Point: Sendable { var x, y: Double }          // implicit
+final class Config: @unchecked Sendable {            // manual: guarded by lock
+    private let lock = NSLock()
+    private var _values: [String: String] = [:]
+}
+```
+
+### 1.5 Global actors and `@MainActor` (Swift 5.5, SE-0316)
+
+A **global actor** is a singleton actor you can attach to any declaration via an attribute. `@MainActor` is the built-in one, isolating code to the main thread/executor.
+
+```swift
+@MainActor final class ViewModel {   // whole type on the main actor
+    var title = ""
+}
+
+@MainActor func updateUI() { ... }
+
+func background() async {
+    await MainActor.run { /* main-actor work */ }
+}
+```
+- Define your own with `@globalActor`:
+  ```swift
+  @globalActor actor DatabaseActor { static let shared = DatabaseActor() }
+  @DatabaseActor func query() { ... }
+  ```
+- A global-actor-isolated non-protocol type is implicitly `Sendable` (SE-0316).
+- **`@MainActor` inference / usability** improved via SE-0434 (Swift 6.0): global-actor-isolated value types relax some `Sendable`/closure restrictions.
+
+### 1.6 Region-based isolation and `sending` (Swift 6.0)
+
+- **Region-based isolation (SE-0414):** the compiler tracks "isolation regions" of values that are provably not shared. A non-`Sendable` value can be passed across an isolation boundary if the compiler proves the sender no longer uses it ("transferring"). This dramatically reduces false positives.
+- **`sending` (SE-0430):** an explicit parameter/result annotation meaning "ownership is transferred across the isolation boundary; the caller must give up the value." Enables passing non-`Sendable` values safely by proving they're not used afterward.
+  ```swift
+  func handoff(_ item: sending Item) async { await store.keep(item) }
+  ```
+- **`@isolated(any)` function types (SE-0431):** a function value that carries its own actor isolation, queryable at runtime — foundational for APIs like `Task` that must run a closure on its original actor.
+
+### 1.7 Swift 6 strict concurrency / complete data-race checking
+
+- **Language mode 6** makes all data-race-safety diagnostics **errors**. In language mode 5, they can be enabled incrementally as warnings via `-strict-concurrency=minimal | targeted | complete`.
+- The compiler statically proves that mutable state is confined to a single isolation domain (an actor, a global actor, or a provably-unshared region). Violations that were runtime crashes/UB in GCD become **compile errors**.
+- **Migration is incremental**: turn on `-strict-concurrency=complete` in language mode 5 first, fix warnings, then flip to language mode 6. Per-target in SwiftPM via `swiftSettings: [.enableExperimentalFeature(...)]` / `swiftLanguageMode(.v6)`.
+- Enabling *specific* upcoming features early: e.g. `-enable-upcoming-feature StrictConcurrency`, `-enable-upcoming-feature InferSendableFromCaptures`.
+
+### 1.8 Swift 6.2 "Approachable Concurrency" (the big 6.2 shift)
+
+Swift 6.2's headline is making single-threaded code *not* fight the concurrency checker. Two opt-in "upcoming features" enabled by Xcode 26's new-project template:
+
+- **Default actor isolation = `MainActor` (SE-0466):** compiler flag `-default-isolation MainActor` (SwiftPM: `defaultIsolation(MainActor)` / build setting `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`). Every unannotated declaration in the module is inferred `@MainActor`. This removes the flood of false-positive data-race errors in ordinary UI/app code — you only opt *out* to background work. Best suited to app modules; library modules that must stay isolation-agnostic should generally **not** enable it.
+- **`nonisolated(nonsending)` / run on caller's actor (SE-0461):** a `nonisolated async` function now runs **on the caller's actor** by default instead of hopping to the generic cooperative pool. This means `async` no longer implicitly means "concurrent." The old "always hop off" behavior is opted into explicitly with **`@concurrent`**:
+  ```swift
+  nonisolated func parse(_ d: Data) async -> Model { ... }   // runs on caller's actor (6.2)
+
+  @concurrent func decodeImage(_ d: Data) async -> Image { ... } // deliberately off the actor
+  ```
+  Guidance: mark genuinely CPU-heavy work `@concurrent` *on purpose and visibly*; leave everything else to inherit the caller's context. `@concurrent` is only valid on `nonisolated` functions.
+- Related 6.2 concurrency items: **isolated `deinit`** (SE-0371, matured), **`Observations`** async sequence for streaming observable state, **backpressure-friendly `AsyncStream`**, task naming for debugging, improved async stepping in LLDB.
+
+**Net effect for reviewers:** In a 6.2 approachable-concurrency module, "make it compile" is often "add `@MainActor` at the boundary" or "mark the heavy function `@concurrent`," not "sprinkle `@unchecked Sendable`."
+
+### 1.9 `AsyncSequence`, `AsyncStream`, continuations
+
+- **`AsyncSequence` / `AsyncIteratorProtocol`** (SE-0298): the async analogue of `Sequence`, consumed with `for await`:
+  ```swift
+  for await line in fileHandle.bytes.lines { print(line) }
+  for try await item in throwingStream { ... }   // throwing variant
+  ```
+  SE-0421 (Swift 6.0) generalized effect polymorphism so `AsyncSequence` composition (map/filter) propagates `throws`/isolation cleanly.
+- **`AsyncStream` / `AsyncThrowingStream`** (SE-0314): bridge callback/delegate/imperative producers into an `AsyncSequence`:
+  ```swift
+  let stream = AsyncStream<Int> { continuation in
+      producer.onValue = { continuation.yield($0) }
+      producer.onDone  = { continuation.finish() }
+      continuation.onTermination = { _ in producer.stop() }
+  }
+  ```
+- **Continuations** (SE-0300) bridge completion-handler APIs to `async`:
+  ```swift
+  let data = try await withCheckedThrowingContinuation { cont in
+      legacyFetch { result in cont.resume(with: result) }
+  }
+  ```
+  Rules: resume **exactly once**. `withCheckedContinuation` traps on misuse (double/never resume); `withUnsafeContinuation` skips the check for performance. Missing/duplicate resume is a classic bug (hang or crash).
+
+### 1.10 Common data-race pitfalls (what the compiler now catches)
+
+- Capturing non-`Sendable` state in a `Task`/`@Sendable` closure.
+- Passing a mutable class instance across actors without `Sendable`.
+- Mutating captured `var` from concurrent tasks.
+- Reentrancy: assuming actor state is unchanged across an internal `await`.
+- Global mutable `var` (now must be `let`, isolated to a global actor, or `nonisolated(unsafe)` — the latter is a review flag).
+- `DispatchQueue`-based "thread confinement" the compiler can't see → forces `@unchecked Sendable`; prefer migrating to an actor.
+
+---
+
+## 2. Value semantics and types
+
+### 2.1 Structs vs. classes vs. enums
+
+| | `struct` | `class` | `enum` |
+|---|---|---|---|
+| Semantics | value (copied) | reference (shared) | value (copied) |
+| Mutation | needs `mutating` on methods | in place | needs `mutating` |
+| Inheritance | no | yes | no |
+| Identity (`===`) | no | yes | no |
+| Deinit | no | yes (`deinit`) | no |
+| Default `Sendable` | if members are | no | if payload is |
+
+**Idiomatic Swift prefers value types** (structs/enums) by default; reach for a class when you need identity, inheritance, deinit, or reference sharing (e.g., a shared mutable resource, Objective-C interop). "Reference type where a value type fits" is a common smell (§13).
+
+### 2.2 Copy-on-write (COW)
+
+Standard-library value types (`Array`, `Dictionary`, `Set`, `String`, `Data`) wrap a reference-typed buffer and copy it lazily only on mutation when `isKnownUniquelyReferenced` is false. So value semantics are preserved without eager deep copies. Custom COW types use `isKnownUniquelyReferenced(&storage)` to implement the same pattern.
+
+### 2.3 `mutating` and `inout`
+
+- `mutating func` — a struct/enum method that reassigns `self` or its stored properties.
+- `inout` parameters — pass-by-value-result (copy in, mutate, copy back at return), *not* pass-by-reference; passed with `&`. Not usable with `async` reentrancy or escaping closures.
+
+### 2.4 Noncopyable types `~Copyable` and ownership (Swift 5.9+, matured through 6.x)
+
+- **`~Copyable` (SE-0390, Swift 5.9):** a struct/enum whose instances have **unique ownership** and cannot be implicitly copied — ideal for resources (file handles, locks, buffers) where duplication is a bug.
+  ```swift
+  struct FileDescriptor: ~Copyable {
+      let fd: Int32
+      consuming func close() { Darwin.close(fd) }   // consumes self; no further use
+      deinit { Darwin.close(fd) }
+  }
+  ```
+- **Parameter ownership modifiers (SE-0377, Swift 5.9):** `borrowing` (temporary read access, value stays valid for caller) and `consuming` (takes ownership, caller can't use it afterward). Mutually exclusive with each other and `inout`.
+- **`consume` operator (SE-0366):** `let y = consume x` ends `x`'s lifetime explicitly.
+- **Noncopyable generics (SE-0427, Swift 6.0):** generics over possibly-noncopyable types via the `~Copyable` constraint; `<T: ~Copyable>` means "T might not be copyable." The stdlib gained `Optional`, `Result`, `UnsafePointer` etc. over noncopyable (SE-0437).
+- **`borrowing`/`consuming` switch (SE-0432, Swift 6.0)** and **partial consumption (SE-0429)** refine pattern matching on noncopyable values.
+
+These are systems-programming / performance features — most application code never needs them, but a reviewer should recognize them and check that `consuming`/`deinit` semantics for resources are correct.
+
+### 2.5 Tuples
+
+Lightweight, structural, value-type aggregates: `let pair = (1, "a")`, `pair.0`, named `(x: 1, y: 2)`. Tuples up to some arity are `Equatable`/`Comparable`/`Sendable` when elements are (SE-0283). Use structs once a tuple gains meaning or is passed around widely.
+
+---
+
+## 3. Error handling
+
+### 3.1 `throws` / `try` / `do`-`catch`
+
+```swift
+enum NetworkError: Error { case offline, timeout }
+
+func load() throws -> Data { ... }
+
+do {
+    let d = try load()
+} catch NetworkError.offline {
+    ...
+} catch {                       // binds `error`
+    log(error)
+}
+```
+- `try` marks a throwing call; `try?` converts to `Optional` (nil on error); `try!` asserts no error (traps otherwise — a review flag, §13).
+- Errors are just values conforming to the empty `Error` protocol.
+
+### 3.2 `rethrows`
+
+A function that throws only if a closure argument throws:
+```swift
+func map<T>(_ transform: (Element) throws -> T) rethrows -> [T]
+```
+
+### 3.3 Typed throws (Swift 6.0, SE-0413)
+
+Declare the concrete error type a function throws:
+```swift
+func parse() throws(ParseError) -> AST { ... }
+
+do {
+    let ast = try parse()
+} catch {                       // `error` is statically ParseError, not `any Error`
+    switch error { ... }        // exhaustive
+}
+```
+- `throws` == `throws(any Error)`; a non-throwing function == `throws(Never)`. This unifies all three under one model and enables generic code parameterized over the failure type.
+- **Guidance:** typed throws is valuable for (a) exhaustive local error handling, (b) embedded/constrained contexts, and (c) generic error-propagating algorithms. For public library APIs, untyped `throws` is often still preferred because a typed error is a rigid part of your ABI/API contract. Don't reach for it reflexively.
+
+### 3.4 `Result<Success, Failure>`
+
+A value-based alternative to `throws`, useful for storing/deferring errors, completion handlers, and `async` bridging. Convert with `Result { try f() }` and `try result.get()`. In modern `async` code, prefer `throws`; `Result` shines when you must *store* an outcome.
+
+### 3.5 `defer`
+
+Runs a block on scope exit (in reverse order of declaration), regardless of how you leave (return/throw/break). Use for cleanup (unlock, close, restore state):
+```swift
+lock.lock(); defer { lock.unlock() }
+```
+
+### 3.6 Errors vs. optionals vs. `precondition`/`fatalError`
+
+- **Optional (`nil`)** — expected absence with one obvious failure mode ("not found"); no explanation needed.
+- **`throws`** — recoverable failure where the *caller* decides how to handle it and *why it failed matters*.
+- **`precondition` / `assert`** — programmer-error contract checks. `assert` compiles out in release; `precondition` stays in release. Trap on violation.
+- **`fatalError` / `preconditionFailure`** — unrecoverable programmer error / unreachable code. Returns `Never`. **`fatalError` on a reachable production path is a serious smell** (§13) — it's for genuinely impossible states, not for "I didn't handle this yet."
+
+---
+
+## 4. Optionals and safety
+
+- **`Optional<Wrapped>`** (`Wrapped?`) models "value or nothing." It's an enum (`.some`/`.none`), not a null pointer.
+- **Optional binding:**
+  ```swift
+  if let user { use(user) }               // shorthand (Swift 5.7, SE-0345): binds same-named
+  guard let user else { return }           // early exit; `user` in scope afterward
+  if let user = maybeUser { ... }          // classic form
+  ```
+- **Optional chaining:** `user?.profile?.name` short-circuits to `nil`.
+- **Nil-coalescing:** `let name = user?.name ?? "Guest"`.
+- **`switch` over optionals**, `map`/`flatMap` on `Optional`, and `Optional.some`/`.none` patterns.
+- **Force unwrap `!` and `try!`:** crash if `nil`/error. Acceptable only where a `nil` is a genuine programmer error you *want* to trap (e.g., a hardcoded resource URL, `@IBOutlet`). High density of `!`/`try!` is the single most common Swift review flag. Prefer `guard let`, `??`, or throwing.
+- **Implicitly unwrapped optionals (`T!`)** — legacy from Obj-C bridging; avoid in new API surface.
+- **`Never`** — the uninhabited type; return type of functions that never return (`fatalError`), and the "no error" case for typed throws (`throws(Never)`). Conforms to `Error`, so it can be a generic error placeholder.
+
+---
+
+## 5. Generics and protocols
+
+### 5.1 Protocol-oriented programming
+
+Swift favors composing behavior from small protocols + protocol extensions (default implementations) over class inheritance. Value types conform to protocols; retroactive conformance (below) extends types you don't own.
+
+### 5.2 Associated types and primary associated types
+
+```swift
+protocol Container {
+    associatedtype Element
+    var count: Int { get }
+    subscript(_ i: Int) -> Element { get }
+}
+```
+- **Primary associated types (SE-0346, Swift 5.7):** expose associated types as angle-bracket parameters for lightweight same-type constraints:
+  ```swift
+  protocol Collection<Element> { associatedtype Element ... }
+  func sum(_ xs: some Collection<Int>) -> Int
+  let items: any Collection<String>
+  ```
+
+### 5.3 Opaque types `some` vs. existentials `any`
+
+- **`some P` (opaque, SE-0244 return / SE-0341 parameter, Swift 5.1 / 5.7):** one *specific, fixed but hidden* concrete type known to the compiler. Preserves type identity, enables static dispatch and associated-type inference, no boxing. `func makeShape() -> some Shape`.
+- **`any P` (existential, SE-0335, Swift 5.6/5.7):** a *box* that can hold *any* conforming type, which can vary at runtime. Requires the explicit `any` spelling. Has dynamic dispatch + heap boxing cost. `var shapes: [any Shape]`.
+- **Rule of thumb:** default to `some` (generics-lite, zero-cost) when the type is fixed at the call site; use `any` only when you genuinely need heterogeneity / to store mixed types. Bare protocol names as types are discouraged — write `any P` explicitly (an upcoming feature makes bare existentials an error: `ExistentialAny`).
+- **Constrained existentials (SE-0353)** and **implicit opening of existentials (SE-0352, Swift 5.7)** let you call generic methods on `any P` values.
+
+### 5.4 Generic constraints and `where`
+
+```swift
+func merge<C: Collection>(_ a: C, _ b: C) -> [C.Element]
+    where C.Element: Comparable { ... }
+
+extension Array where Element: Numeric { func total() -> Element { reduce(0, +) } }
+```
+
+### 5.5 Parameter packs / variadic generics (Swift 5.9, SE-0393; types SE-0398)
+
+Abstract over an *arbitrary number of heterogeneous types*:
+```swift
+func zipAll<each T>(_ item: repeat each T) -> (repeat each T) {
+    (repeat each item)
+}
+struct Tuple<each Element> { var elements: (repeat each Element) }   // SE-0398
+```
+`each T` is a type pack; `repeat` expands it. This is how variadic-arity generic APIs (e.g., SwiftUI's `TupleView`, `Regex` captures) are built without N hand-written overloads.
+
+### 5.6 Conditional and retroactive conformance
+
+- **Conditional conformance (SE-0143):** `extension Array: Equatable where Element: Equatable`.
+- **Retroactive conformance:** conforming a type you don't own to a protocol you don't own. Allowed but risky (two modules could both do it). Swift 6 asks you to spell it `extension OtherType: @retroactive Proto` (SE-0364) to acknowledge the hazard.
+
+---
+
+## 6. Macros (Swift 5.9)
+
+Compile-time source-to-source transforms, type-checked both before and after expansion, implemented as separate compiler-plugin executables built on **`swift-syntax`** (the `SwiftSyntaxMacros` module). Two families:
+
+### 6.1 Freestanding macros (`#name`)
+- **Expression macros (SE-0382):** `#foo(...)` produces an expression. Examples: `#warning`, `#url`, `#expect` (Swift Testing), the classic `#stringify`.
+- **Freestanding declaration macros (SE-0397):** produce declarations, e.g. `#Preview { ... }`.
+
+### 6.2 Attached macros (`@Name`, SE-0389)
+Attach to a declaration and augment it via roles:
+- `@attached(peer)` — add sibling declarations (e.g. a completion-handler twin of an async func).
+- `@attached(accessor)` — add get/set (property-wrapper-like storage).
+- `@attached(memberAttribute)` / `@attached(member)` — add members / annotate members.
+- `@attached(extension)` (formerly conformance) — add protocol conformances + members.
+- Real examples: **`@Observable`** (Observation framework — synthesizes change tracking), `@Model` (SwiftData), `@CodingKeys`-style helpers.
+
+### 6.3 When to write one
+Only when you have **repetitive boilerplate that can't be expressed with generics, protocol extensions, or property wrappers**, and the transform is mechanical. Macros are hard to debug, add a `swift-syntax` build dependency (compile-time cost), and complicate readability. For a reviewer: a macro should replace *real* duplicated code, come with tests (macros are unit-testable via `assertMacroExpansion`), and not hide surprising control flow.
+
+---
+
+## 7. Memory management (ARC)
+
+- **ARC** (Automatic Reference Counting) manages **class** (and closure/actor) lifetimes deterministically via retain/release inserted at compile time — not a tracing GC. Value types are not reference-counted (though their COW buffers are).
+- **Retain cycles:** two objects (or an object and a closure) strongly referencing each other never deallocate. The two tools:
+  - **`weak`** — optional, auto-nils when the referent deallocates. Use when the referent can legitimately outlive/predecease you (delegates, parent↔child back-references).
+  - **`unowned`** — non-optional, assumes the referent outlives self; **crashes (or UB) on access after dealloc**. Use only when the lifetime relationship is guaranteed.
+- **Capture lists** break closure cycles:
+  ```swift
+  loader.onDone = { [weak self] in self?.finish() }
+  Task { [weak self] in await self?.refresh() }
+  ```
+  In escaping/stored closures that reference `self`, `[weak self]` is the default idiom; forgetting it is the classic iOS leak. (In *structured* `async` code that doesn't outlive `self`, a capture may be fine — not every closure needs `[weak self]`.)
+- **Value types avoid cycles entirely** — another reason to prefer structs/enums. A graph of value types cannot leak via reference cycles.
+- `deinit` runs at deallocation (classes/actors only); use for releasing non-ARC resources.
+
+---
+
+## 8. Expressive features
+
+- **Property wrappers (SE-0258, Swift 5.1):** `@propertyWrapper` types factor out accessor patterns (`wrappedValue`, optional `projectedValue` exposed as `$name`). Language-level (`@State`, `@Published` are framework uses). Write one when several properties share get/set logic (clamping, thread-safety, persistence).
+- **Result builders (`@resultBuilder`, SE-0289, Swift 5.4):** transform a braced sequence of expressions into one value via `buildBlock`/`buildOptional`/`buildEither`/`buildArray`/`buildExpression`. The mechanism behind SwiftUI's `ViewBuilder`, `RegexBuilder`, and custom DSLs. A reviewer should recognize a result-builder closure isn't ordinary imperative code.
+- **Key paths (`\Type.property`):** first-class, composable references to properties/subscripts. `\User.name`, used in `sort(by:)`, `map(\.id)`, `@dynamicMemberLookup`, Combine/SwiftUI bindings. Writable key paths, reference key paths.
+- **`@dynamicMemberLookup` (SE-0195) / `@dynamicCallable` (SE-0216):** allow `x.anything` / `x(...)` to route through a subscript/method — for interop bridges and ergonomic wrappers. Use sparingly; they defeat autocomplete and type-checking of member names.
+- **Pattern matching / `switch`:** value binding, `where` guards, tuple patterns, `case let`, optional patterns, range patterns, enum-with-payload matching. **Exhaustiveness** is enforced for enums (no `default` needed if all cases covered) — a key safety property; a `default` on a closed enum can hide the "new case not handled" review signal. `if case`/`guard case` for single-pattern matches. `for case let x? in optionals` filters nils.
+- **Extensions:** add methods/computed properties/conformances/nested types to any type (including generics conditionally). Cannot add stored properties. Idiomatic organizing tool (one extension per protocol conformance).
+
+---
+
+## 9. Swift Package Manager (SwiftPM)
+
+The manifest is **`Package.swift`**, itself Swift code evaluated in a sandbox; the first line pins the manifest API/tools version:
+
+```swift
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "MyLib",
+    platforms: [.macOS(.v14), .iOS(.v17)],
+    products: [
+        .library(name: "MyLib", targets: ["MyLib"]),
+        .executable(name: "mytool", targets: ["mytool"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(path: "../LocalUtils"),        // local package for modularization
+    ],
+    targets: [
+        .target(
+            name: "MyLib",
+            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
+            resources: [.process("Resources"), .copy("data.json")],
+            swiftSettings: [.swiftLanguageMode(.v6), .defaultIsolation(MainActor)]
+        ),
+        .testTarget(name: "MyLibTests", dependencies: ["MyLib"]),
+        .plugin(name: "MyPlugin", capability: .buildTool()),
+    ]
+)
+```
+
+- **Concepts:** *targets* (build units — `.target`, `.executableTarget`, `.testTarget`, `.macro`, `.plugin`, `.systemLibrary`, `.binaryTarget`), *products* (`.library`, `.executable`, `.plugin` — what dependents import), *dependencies* (git URL + version range, or `path:` for local).
+- **Versioning:** semantic-version requirements — `from:`, `.upToNextMajor(from:)`, `.upToNextMinor(from:)`, `exact:`, `branch:`, `revision:`. Resolution is recorded in `Package.resolved`.
+- **Resources (SE-0271):** `.process` (platform-optimized) vs `.copy` (verbatim); access via `Bundle.module`.
+- **Plugins (SE-0303/SE-0325, Swift 5.6/5.7):** *build-tool plugins* (code generation in the build graph) and *command plugins* (`swift package <verb>` — linting, formatting, docs).
+- **Per-target settings:** `swiftSettings`/`cSettings`/`cxxSettings`/`linkerSettings`, including `.enableUpcomingFeature`, `.enableExperimentalFeature`, `.unsafeFlags`, `.interoperabilityMode(.Cxx)`.
+- **Local packages** are the idiomatic way to modularize an app: split features into path-referenced packages for build isolation, faster incremental builds, and enforced dependency boundaries.
+
+---
+
+## 10. API Design Guidelines (swift.org, authoritative)
+
+The guidelines are the canonical standard a Swift reviewer cites. Core principles:
+
+**Fundamentals**
+- **Clarity at the point of use** is the most important goal — APIs are declared once but *used* many times. Optimize the call site.
+- **Clarity is more important than brevity.** Don't abbreviate to save characters.
+- **Write a doc comment for every declaration.** If it's hard to describe simply, reconsider the API.
+
+**Promote clear usage**
+- Include words that avoid ambiguity: `remove(at: index)` not `remove(index)`.
+- Omit needless words — especially those merely repeating type info: `remove(_:)` not `removeElement(_:)`.
+- Name variables/parameters/associated types by **role**, not type (`supplier`, not `widgetFactory`).
+- Compensate for weak type info (e.g., `Any`, `NSObject`) with a noun describing the role.
+
+**Strive for fluent usage**
+- Method/function names should read as grammatical English phrases at the call site: `x.insert(y, at: z)`, `x.subViews(havingColor: y)`.
+- Begin factory methods with `make`: `x.makeIterator()`.
+- **Side-effect naming:** mutating verbs get imperative names (`x.sort()`, `x.append(y)`); their nonmutating counterparts read as nouns/`-ed`/`-ing` (`z = x.sorted()`, `y.union(z)`). Noun-based mutating pairs use `form`: `y.formUnion(z)`.
+- Boolean methods/properties read as assertions about the receiver: `x.isEmpty`, `line1.intersects(line2)`.
+- Protocols describing *what something is* are nouns (`Collection`); those describing a *capability* use `-able`/`-ible` (`Equatable`, `ProgressReporting`).
+
+**Conventions**
+- `UpperCamelCase` for types/protocols; `lowerCamelCase` for everything else. Acronyms are uniformly cased (`utf8`, not `uTF8`; `ASCII` all caps when leading a type).
+- **Argument labels:** omit when arguments can't be usefully distinguished (`min(x, y)`); omit the first label in full-width value-preserving conversions (`Int64(someUInt32)`); use labels that form a grammatical phrase with the base name; prefer prepositional phrases (`moveTo(x:y:)` → `move(to:)`). Default parameters simplify long signatures.
+- Avoid overloading solely on return type. Prefer methods/properties over free functions. Take advantage of defaulted parameters.
+
+**Documentation comments**
+- Begin with a single summary sentence in the imperative for methods ("Returns…", "Inserts…"), fragment for properties. Use Swift-flavored Markdown, `- Parameter`/`- Parameters`, `- Returns`, `- Throws`, and callouts (`- Note:`, `- Warning:`, `- Precondition:`).
+
+---
+
+## 11. Testing (language-level): Swift Testing vs. XCTest
+
+**Swift Testing** (shipped with Swift 6 / Xcode 16, WWDC 2024; enhanced in 6.2) is the modern, macro-driven, open-source framework. It coexists with and is gradually replacing **XCTest**.
+
+```swift
+import Testing
+
+@Test func addsCorrectly() {
+    #expect(add(2, 3) == 5)                       // soft check: records, continues
+}
+
+@Test("Parses ISO date", .tags(.parsing))
+func parsing() throws {
+    let d = try #require(parseDate("2025-09-15")) // hard check: unwraps or fails+stops
+    #expect(d.year == 2025)
+}
+
+@Suite("Math", .serialized)
+struct MathTests {
+    @Test(arguments: [0, 1, 2, 3])                // parameterized: one child test per arg
+    func isEvenDoubled(_ n: Int) {
+        #expect((n * 2) % 2 == 0)
+    }
+
+    @Test(arguments: zip([1,2], [2,4]))           // multi-arg via zip
+    func doubles(_ input: Int, _ expected: Int) {
+        #expect(input * 2 == expected)
+    }
+}
+```
+
+- **Macros:** `@Test` (any function, sync or `async`, `throws`; no `test` prefix needed), `@Suite` (a grouping type), `#expect` (records failure, keeps going, captures sub-expression values on failure), `#require` (throws `ExpectationFailedError` and stops the test — for preconditions and unwrapping optionals).
+- **Traits:** `.tags(...)`, `.enabled(if:)`, `.disabled("reason")`, `.bug(url)`, `.timeLimit(...)`, `.serialized` (opt out of parallelism). Traits replace XCTest's naming conventions / overrides.
+- **Parameterized tests** (`@Test(arguments:)`) produce one parent + one child per input, run in parallel — far better than a `for` loop inside one test (isolated failures, individual re-runs).
+- **Parallel by default** (in-process, across tests) — tests must be independent; shared mutable global state becomes a real hazard. Swift Testing integrates with Swift concurrency (`async` tests, actor isolation) natively.
+- **Error checking:** `#expect(throws: MyError.self) { try f() }` / `#expect(throws: MyError.timeout)`.
+- **What stays in XCTest:** UI automation (`XCUIApplication`/XCUITest) and performance measurement (`XCTMetric`/`measure`). New unit tests should generally use Swift Testing; the two frameworks run side by side in the same target for incremental migration.
+
+---
+
+## 12. Interoperability
+
+### 12.1 Objective-C
+- **Automatic bridging** both directions within a module/framework; Foundation value bridging (`String`↔`NSString`, `Array`↔`NSArray`, etc.).
+- **`@objc`** exposes a Swift declaration to the Obj-C runtime; **`@objc(customName)`** renames; **`@objcMembers`** exposes a whole class. Required for selector-based APIs (`#selector`), KVO/KVC, dynamic dispatch (`dynamic`).
+- **`@_cdecl`**, `NS_SWIFT_NAME`, nullability audit macros (`NS_ASSUME_NONNULL_BEGIN`) shape how Obj-C imports into Swift. Swift `Error`↔`NSError` bridging via `NSError` domain/code.
+- Bridging header exposes Obj-C to Swift in a mixed app target.
+
+### 12.2 C
+- Import C libraries directly via a **module map** / `.systemLibrary` target or a bridging header. C types map to Swift (`Int32`, `UnsafePointer<T>`, `OpaquePointer`, function pointers via `@convention(c)` closures). `withUnsafePointer`, `withUnsafeBytes` for buffer access. `CInt`, `CChar`, etc. typealiases.
+
+### 12.3 C++ interop (Swift 5.9+, bidirectional)
+- **Opt-in** per target: `swiftSettings: [.interoperabilityMode(.Cxx)]` in SwiftPM (or `-cxx-interoperability-mode=default`). Off by default because it changes name lookup.
+- **Swift→C++:** call C++ functions, use C++ types, methods, templates, `std::string`/`std::vector` (mapped to Swift with iteration support), owned/reference-semantics annotations (`SWIFT_SHARED_REFERENCE`, `SWIFT_IMMORTAL_REFERENCE`).
+- **C++→Swift:** the compiler generates a C++ header exposing Swift APIs to C++ callers.
+- Maturity is documented at swift.org/documentation/cxx-interop/status (some C++ features — exceptions, certain templates, virtual inheritance — are unsupported or constrained). C++ `move`-only types map toward Swift `~Copyable`.
+- Reviewer note: enabling C++ interop is a build-wide decision with compile-time and API-surface implications; scope it to the targets that need it.
+
+---
+
+## 13. Idioms, anti-patterns, and language "debt"
+
+**Idiomatic Swift a reviewer should reward**
+- Value types by default; classes only for identity/inheritance/shared mutable state.
+- `guard let`/`guard` for early exits and flat control flow; minimal nesting.
+- Protocol + protocol-extension composition over class hierarchies.
+- `some` over `any` unless heterogeneity is required; explicit `any`.
+- Exhaustive `switch` on closed enums (no defensive `default`).
+- Errors typed by domain; `throws` for recoverable, optionals for simple absence.
+- Small, focused functions and extensions grouped by conformance.
+- Clear API naming per the official guidelines (fluent call sites, right argument labels).
+- Concurrency isolation modeled with actors / `@MainActor`, not manual queues.
+
+**Anti-patterns / smells to flag**
+- **Force-unwrap `!` and `try!` density** — each is a potential crash; flag clusters and any on non-invariant paths. Prefer `guard let`/`??`/`throws`.
+- **`fatalError`/`preconditionFailure` on reachable production paths** — fine for truly-impossible states and `required init?(coder:)`-style stubs, not for unhandled cases or "TODO."
+- **Massive functions / massive types** — long methods, "god" view models/managers; extract and use extensions.
+- **`@unchecked Sendable` overuse** — every one asserts a safety property the compiler can't check; demand a comment naming the lock/queue and prefer migrating to an actor.
+- **Silencing concurrency diagnostics** — `nonisolated(unsafe)`, `@preconcurrency` imports left permanently, `-strict-concurrency` downgraded, `@Sendable` closures wrapping unsynchronized state, `Task { @MainActor in ... }` sprinkled to paper over isolation instead of modeling it. In Swift 6.2, prefer default `MainActor` isolation + explicit `@concurrent` over ad-hoc suppression.
+- **Reference types where value types fit** — a `class` with only value data and no identity/sharing need; forces manual `Sendable`/cycle management.
+- **Stringly-typed code** — magic strings for keys/identifiers/states; prefer enums, `RawRepresentable`, key paths, and typed IDs.
+- **`Task.detached` by default** — silently drops isolation/priority/task-locals; usually should be `Task { }`.
+- **Retain cycles** — stored/escaping closures capturing `self` strongly without `[weak self]`; delegate references not `weak`.
+- **Ignoring cancellation** — long-running tasks that never check `Task.isCancelled` / `checkCancellation()`.
+- **Bare existentials & implicit Obj-C dynamism** — un-`any`'d protocol types; unnecessary `@objc dynamic`.
+- **Blocking the main actor** — synchronous heavy work or `DispatchSemaphore.wait()` on `@MainActor`; move to `@concurrent`/an actor.
+
+**Swift 6 / concurrency migration guidance**
+1. Build with the 6.x compiler in **language mode 5** first — no behavior change, but you can adopt features incrementally.
+2. Turn on `-strict-concurrency=complete` (warnings) and adopt upcoming features per-target (`InferSendableFromCaptures`, `RegionBasedIsolation`, etc.).
+3. Fix warnings by *modeling* isolation: put UI/state on `@MainActor`, wrap shared mutable state in `actor`s, add `Sendable` conformances, use `sending` for handoffs — rather than reaching for `@unchecked`/`nonisolated(unsafe)`.
+4. Flip to **language mode 6** target by target once warnings are clean.
+5. On Swift 6.2, consider **approachable concurrency** (`defaultIsolation(MainActor)` + `@concurrent` for heavy work) for app modules to cut boilerplate; keep isolation-agnostic libraries explicit.
+6. Use `@preconcurrency import` as a *temporary* bridge for not-yet-annotated dependencies, and Xcode/Swift migration tooling to apply mechanical edits.
+
+---
+
+## Sources
+
+### Official (swift.org / Apple)
+- Swift 6.2 released — https://www.swift.org/blog/swift-6.2-released/
+- Announcing Swift 6 — https://www.swift.org/blog/announcing-swift-6/
+- Swift 6 concurrency migration guide — https://www.swift.org/migration/documentation/migrationguide/
+- Swift concurrency documentation — https://www.swift.org/documentation/concurrency/
+- API Design Guidelines — https://www.swift.org/documentation/api-design-guidelines/
+- Mixing Swift and C++ — https://www.swift.org/documentation/cxx-interop/ ; status — https://www.swift.org/documentation/cxx-interop/status/
+- What's New in Swift (Apple Developer) — https://developer.apple.com/swift/whats-new/
+- The Swift Programming Language (book) — https://docs.swift.org/swift-book/
+- Swift Evolution proposals (github.com/swiftlang/swift-evolution/proposals): SE-0296 async/await, SE-0298 AsyncSequence, SE-0300 continuations, SE-0302 Sendable, SE-0304 structured concurrency, SE-0306 actors, SE-0314 AsyncStream, SE-0316 global actors, SE-0317 async let, SE-0335 existential any, SE-0341 opaque parameters, SE-0346 primary associated types, SE-0352 implicit open existentials, SE-0353 constrained existentials, SE-0364 retroactive conformance, SE-0366 consume operator, SE-0377 ownership modifiers, SE-0381 discarding task groups, SE-0382 expression macros, SE-0389 attached macros, SE-0390 noncopyable structs/enums, SE-0392 custom executors, SE-0393 parameter packs, SE-0397 freestanding declaration macros, SE-0398 variadic types, SE-0411 isolated default values, SE-0413 typed throws, SE-0414 region-based isolation, SE-0420 actor isolation inheritance, SE-0421 AsyncSequence effect polymorphism, SE-0427 noncopyable generics, SE-0429 partial consumption, SE-0430 `sending`, SE-0431 `@isolated(any)`, SE-0432 noncopyable switch, SE-0434 global-actor-isolated type usability, SE-0437 noncopyable stdlib primitives, SE-0461 nonisolated async on caller's actor + `@concurrent`, SE-0466 default actor isolation.
+- Swift Testing (github.com/swiftlang/swift-testing) and Apple developer docs.
+
+### Community (secondary — corroboration / examples)
+- Matt Massicotte's concurrency series — https://www.massicotte.org/ (SE-0430, SE-0420, SE-0411, SE-0434, concurrency glossary)
+- Donny Wals, "Exploring concurrency changes in Swift 6.2" — https://www.donnywals.com/exploring-concurrency-changes-in-swift-6-2/
+- Antoine van der Lee (SwiftLee): approachable concurrency, existential any, parameter packs — https://www.avanderlee.com/
+- Hacking with Swift — What's new in Swift 5.9 / 6.0 / 6.2, macros, variadic generics — https://www.hackingwithswift.com/
+- QuickBird Studios, "Swift Macros" — https://quickbirdstudios.com/blog/swift-macros/
+- Michael Tsai, "Swift 6.2: Approachable Concurrency" — https://mjtsai.com/blog/2025/11/03/swift-6-2-approachable-concurrency/
+
+*Version-sensitive items are labeled inline. Where a secondary source is cited for a version/SE fact, it was cross-checked against the official swift.org release blog or the swift-evolution proposal.*

--- a/research/swift-language/README.md
+++ b/research/swift-language/README.md
@@ -1,0 +1,26 @@
+# Swift Language — Research Reference
+
+Authoritative reference on **the Swift language** (Swift 6.2, released 15 September 2025), gathered to
+ground the [`language-swift-expert`](../../agents/sdlc/language-swift-expert.md) agent (feature #223,
+EPIC #217).
+
+**Compiled:** 2026-07-23. Features are tagged with the introducing Swift version and Swift Evolution
+proposal (`SE-NNNN`). Version-sensitive concurrency details (6.2 is recent and evolving) should be
+re-checked against swift.org. Scope is the **language**, not UI frameworks (SwiftUI/UIKit →
+`swiftui-architect` / `apple-hig-architect`).
+
+## Contents
+
+| File | Covers |
+|------|--------|
+| [`01-swift-language.md`](01-swift-language.md) | Concurrency (async/await, structured concurrency, actors, `Sendable`, global actors, region-based isolation, Swift 6 strict concurrency, Swift 6.2 approachable concurrency), value semantics & noncopyable types, error handling (typed throws), optionals/safety, generics & protocols (opaque vs existential, primary associated types, parameter packs), macros, ARC, expressive features, SwiftPM, the API Design Guidelines, Swift Testing, C/Obj-C/C++ interop, and idioms/anti-patterns/"language debt" + Swift 6 migration |
+
+## Key facts at a glance
+
+- **Language mode vs compiler version**: mode 6 turns on complete data-race checking as errors; a 6.2 compiler can still build mode 5. Migrate incrementally (`-strict-concurrency=complete` → mode 6).
+- **Swift 6.2 "approachable concurrency"** (the big recent shift): default `MainActor` isolation (SE-0466) + `nonisolated async` runs on the caller's actor with `@concurrent` as the explicit background opt-out (SE-0461). Review guidance becomes "add `@MainActor`/`@concurrent`", not "sprinkle `@unchecked Sendable`."
+- **Value types by default**; classes only for identity/inheritance/shared mutable state. Noncopyable `~Copyable` + `consuming`/`borrowing` for unique-ownership resources.
+- **Typed throws** (SE-0413) — use for exhaustive local handling / generic error propagation; untyped `throws` still preferred for most public APIs.
+- **`some` (opaque) over `any` (existential)** unless heterogeneity is needed; spell `any` explicitly.
+- **Swift Testing** (`@Test`/`#expect`/`#require`, parameterized, parallel) for unit tests; XCTest for UI + performance.
+- **Top review smells**: force-unwrap/`try!` density, `fatalError` on live paths, `@unchecked Sendable`/`nonisolated(unsafe)` overuse, `Task.detached`, ignored cancellation, reference-where-value-fits, stringly-typed code.

--- a/retrospectives/223-ios-closure-swift-lang.md
+++ b/retrospectives/223-ios-closure-swift-lang.md
@@ -1,0 +1,66 @@
+# Retrospective: iOS closure — ios-scaffold skill + sdlc-lang-swift
+
+**Branch:** `feature/ios-closure-swift-lang`
+**Date:** 2026-07-23
+**Duration:** ~1 session (scaffold skill + Swift research + agent + wiring)
+
+---
+
+## Summary
+
+Closing out the iOS story in EPIC #217: adding an `ios-scaffold` skill (submission-safe project
+defaults) and a `sdlc-lang-swift` plugin with `language-swift-expert` — resolving decision D2 in
+favour of a dedicated language plugin (consistent with `sdlc-lang-python`/`-javascript`). Living
+document, completed before PR.
+
+## What Went Well
+
+- **D2 resolved by convention, not debate**: the two existing language plugins made "separate
+  `sdlc-lang-swift`" the obvious, consistent choice.
+- **ios-scaffold encodes prevention**: it pre-wires exactly the config the #222 pre-flight checker
+  looks for (export compliance, git-stamped build number, sandboxing), so new projects start clean.
+- **Current, SE-tagged Swift research**: the reference tagged every feature with its Swift version +
+  evolution proposal and led with Swift 6.2 "approachable concurrency" — so the agent's guidance is
+  accurate about language-mode-vs-compiler-version, not folklore.
+
+## What Could Improve
+
+- **Marketplace JSON reformatting**: a `json.dump` bulk-rewrite reflowed the compact one-line-per-plugin
+  format to indented multi-line + `—` escapes. Caught immediately; reverted with `git checkout`
+  and re-applied as minimal one-line Edits. Lesson: **edit the compact JSON entries directly; never
+  round-trip the whole file through `json.dump`.** (Two later version bumps were done with `json.dump`
+  on the individual `plugin.json` files — those are already pretty-printed, so that's fine; only the
+  hand-formatted `marketplace.json` needs targeted edits.)
+- **Two broken-reference false positives from prose** (`project.yml`, and earlier `.github/...yml`) —
+  the checker reads bare `filename.ext` tokens in backticked prose as links. Reworded. Same recurring
+  class as `Motion.md`/`<page>.json`; a prose-allowlist in the checker would end it.
+
+## Lessons Learned
+
+1. **Prefer targeted text edits over full-file re-serialization** for hand-formatted config (marketplace.json).
+2. **Convention beats deliberation for well-precedented decisions.** D2 (Swift language plugin placement)
+   was open for several phases; the two existing `sdlc-lang-*` plugins made "separate plugin" the
+   obvious answer once it was time to build.
+3. **Scaffolding-as-prevention closes the loop with the checker.** `ios-scaffold` and the #222
+   pre-flight checker are two halves of one idea — generate config that passes, then verify it stays passing.
+
+## Changes Made
+
+### Files Created
+- `docs/feature-proposals/223-ios-closure-swift-lang.md`, `retrospectives/223-ios-closure-swift-lang.md`
+- `skills/ios-scaffold/SKILL.md` (+ plugin copy)
+- `plugins/sdlc-lang-swift/` (plugin.json, README, agents/) + `agents/sdlc/language-swift-expert.md` _(pending research)_
+- `research/swift-language/` _(pending)_
+
+### Files Modified
+- `release-mapping.yaml` — ios-scaffold skill + sdlc-lang-swift section
+- `.claude-plugin/marketplace.json` — +sdlc-lang-swift; sdlc-team-ios → 0.4.0; sdlc-core → 1.3.0
+- `plugins/sdlc-team-ios/.claude-plugin/plugin.json` → 0.4.0; `plugins/sdlc-core/.claude-plugin/plugin.json` → 1.3.0
+- `skills/setup-team/SKILL.md` (+ plugin copy) — recommend sdlc-lang-swift for iOS/cross-platform
+- `plugins/sdlc-team-ios/README.md`, `CLAUDE.md`, `README.md` — counts/tables
+
+## Action Items
+
+- [ ] Complete `language-swift-expert` from research; regenerate catalog; validate; PR
+- [ ] **Android platform agents — the next sub-epic** (kotlin-android, jetpack-compose, app-architect, gradle, play-store, performance)
+- [ ] Optional iOS: `fastlane-setup` skill; Swift lint/debt validators in sdlc-lang-swift

--- a/skills/ios-scaffold/SKILL.md
+++ b/skills/ios-scaffold/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ios-scaffold
+description: Scaffold a new iOS app with SDLC and submission-safe defaults — diffable project files, app + test targets, deployment-target policy, a git-stamped build number, and the Info.plist keys the pre-flight checker wants so the project passes TestFlight from day one. Use when starting a new iOS project.
+disable-model-invocation: false
+argument-hint: "[app-name]"
+---
+
+# iOS Scaffold
+
+Create a new iOS app project that is **submission-safe from the first commit** — so it doesn't hit the
+TestFlight/App Store blockers `ios-testflight-release` and the pre-flight checker exist to catch.
+Belongs to the **`sdlc-team-ios`** plugin; pairs with `swiftui-architect` (structure) and
+`swift-language-expert` (language).
+
+## Arguments
+
+- `app-name` — the app / bundle name (defaults to asking).
+
+## Steps
+
+### 1. Choose the project-generation approach
+
+Prefer a **diffable, mergeable** project definition over a hand-managed `.xcodeproj`:
+
+- **Swift Package Manager** (an app built as a package + a thin app target) for library-first / simple apps.
+- **Tuist** or **XcodeGen** to generate the `.xcodeproj` from a committed manifest (Tuist's `Project.swift`, or an XcodeGen YAML manifest)
+  that *is* committed, so project changes review cleanly and don't cause merge conflicts.
+
+Ask which the team prefers; default to XcodeGen/Tuist for an app that needs a real Xcode project.
+
+### 2. Establish structure
+
+- **App target** + **unit-test target** (Swift Testing) + optional **UI-test target** (XCUITest).
+- A **SwiftPM feature-module** layout if the app is non-trivial (feature packages + Core/DesignSystem/
+  Models; thin app composition root) — see `swiftui-architect`.
+- `.gitignore` covering `*.xcodeproj` (if generated), `DerivedData/`, `.build/`, `*.xcuserstate`,
+  `.DS_Store`, and any secrets file.
+
+### 3. Wire submission-safe Info.plist defaults (this is the point of the skill)
+
+Pre-set the keys the pre-flight checker looks for, so uploads don't stall or get rejected later:
+
+- **`ITSAppUsesNonExemptEncryption = false`** (if the app uses only exempt encryption such as standard
+  HTTPS) — skips the export-compliance questionnaire on every upload.
+- A **`NS…UsageDescription`** placeholder-with-a-real-sentence for each capability the app will use
+  (add them as you add frameworks; the pre-flight check maps CoreMotion→`NSMotionUsageDescription`,
+  etc.). Leave a comment reminding that these must be real human sentences.
+- Set the **deployment target** to the team's minimum-supported iOS per policy (and keep it consistent
+  across targets and `Package.swift`).
+
+### 4. Git-stamped, monotonic build number
+
+- Keep `MARKETING_VERSION` fixed pre-1.0 (e.g. `1.0.0`) and stamp **`CFBundleVersion` from
+  `git rev-list --count HEAD`** (optionally plus the short SHA and date) in a **build-phase script**,
+  so every build is unique, monotonic, and traceable to a commit.
+- On the target that runs that script, set **`ENABLE_USER_SCRIPT_SANDBOXING = NO`** (leave it `YES`
+  elsewhere) — a script that reads git/the environment fails to archive under the sandbox otherwise.
+
+### 5. Release-default safety
+
+- Gate debug menus, feature flags, verbose logging, and staging endpoints behind a build config or a
+  flag that is **OFF in Release** unless explicitly enabled.
+- No secrets/API keys in the repo or the bundle — use `.xcconfig`/build settings + a secrets mechanism.
+
+### 6. CI and privacy manifest
+
+- Offer to run `ios-ci` to generate the GitHub Actions workflow (which gates on the pre-flight checks).
+- Add a `PrivacyInfo.xcprivacy` stub if the app will use required-reason APIs or bundle third-party SDKs.
+
+### 7. Verify
+
+- Build once; run the unit-test target; and run the pre-flight checker
+  (`python -m ios_preflight.cli <project>`) — it should be clean (or only INFO) on a fresh scaffold.
+
+### 8. Report
+
+Summarise what was generated, the generation approach chosen, the build-number policy, and confirm the
+pre-flight checker is clean. Note anything the user must fill in (real purpose strings, signing team).
+
+## Notes
+
+- The goal is a project that passes `ios-testflight-release` pre-flight on day one — don't leave the
+  export-compliance key or build-number policy "for later".
+- For app *architecture* choices (state, navigation, persistence), hand off to `swiftui-architect`; for
+  idiomatic Swift, to `swift-language-expert`.

--- a/skills/setup-team/SKILL.md
+++ b/skills/setup-team/SKILL.md
@@ -107,9 +107,9 @@ Look for `.sdlc/team-config.json` in the project root (or `.claude/team-config.j
    | C. Cloud | `sdlc-team-common`, `sdlc-team-cloud` |
    | D. API | `sdlc-team-common`, `sdlc-team-fullstack`, `sdlc-team-cloud` |
    | E. Security | `sdlc-team-common`, `sdlc-team-security` |
-   | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile` |
+   | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile`, `sdlc-lang-swift` |
    | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile` |
-   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile` |
+   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift` |
    | F. Custom | `sdlc-team-common` (pre-selected) + user picks additional team plugins |
 
    **Mobile plugins pair with the shared base.** `sdlc-team-ios` (Apple HIG) and `sdlc-team-android` (Material Design 3) each carry only their platform's design specialist; the cross-platform agents (`mobile-architect`, `mobile-ux-architect`) live once in `sdlc-team-mobile`. Always recommend the platform plugin **and** `sdlc-team-mobile` together — the marketplace has no hard dependency resolution, so this recommendation is the pairing mechanism. A cross-platform team installs both platform plugins + the single shared base (agents are never duplicated).


### PR DESCRIPTION
**Part of #217 (EPIC). Closes #223. Resolves EPIC #217 decision D2.** Completes the iOS story before Android becomes a sub-epic.

## Two finishing pieces

### `ios-scaffold` skill (`sdlc-team-ios` 0.3.0 → 0.4.0)
Scaffolds a new iOS app with **submission-safe defaults**, so it passes the #222 pre-flight checker from day one: diffable project files (SwiftPM/Tuist/XcodeGen), app + test targets, deployment-target policy, `ITSAppUsesNonExemptEncryption`, usage-string placeholders, a **git-stamped `CFBundleVersion`** build phase with **`ENABLE_USER_SCRIPT_SANDBOXING=NO`**, and release-default-safe flags. Scaffolding-as-prevention — the other half of the pre-flight checker.

### `sdlc-lang-swift` plugin (0.1.0) — `language-swift-expert`
**Resolves D2**: Swift gets a dedicated language plugin, consistent with `sdlc-lang-python` / `sdlc-lang-javascript` (Swift is also used server-side / other Apple platforms). Grounded in swift.org deep research (every feature SE-tagged), Swift 6.2 baseline:
- Strict concurrency (async/await, actors, `Sendable`, **Swift 6.2 approachable concurrency** — default `MainActor` isolation + `@concurrent`), value semantics & noncopyable types, typed throws, generics/protocols (`some` vs `any`, parameter packs), macros, ARC, SwiftPM, API Design Guidelines, Swift Testing, Obj-C/C/C++ interop, and an idiomatic/anti-pattern review checklist.
- Scope is **the language**, not SwiftUI/UIKit — clean boundaries + cross-references with `swiftui-architect`.

## iOS is now complete (EPIC #217)
`sdlc-team-ios` (design → architecture → release → performance + scaffold/release skills + pre-flight checks) **+ `sdlc-lang-swift`** (the language). Android is the next **sub-epic**.

## Wiring
release-mapping (scaffold skill + new plugin) · marketplace (+plugin; `sdlc-team-ios` 0.4.0; `sdlc-core` 1.2.0 → **1.3.0** for the setup-team recommendation) · setup-team matrix recommends `sdlc-lang-swift` for iOS/cross-platform · AGENT-INDEX/CATALOG regenerated (18 plugins, 16 ship agents) · READMEs + CLAUDE.md.

## Validation
- Full suite **(815) passes**; `validate-agent-format` + `validate-agent-official` PASS
- `check-plugin-packaging` PASS (18 plugins); `check-technical-debt .` COMPLIANT; `check-broken-references` clean for new files; non-ASCII scan clean
- `check-feature-proposal` properly formatted; plugin ↔ marketplace versions agree

Agent/skill/research markdown + JSON/YAML only — no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)