### PR TITLE
feat(sdlc-lang-kotlin): language-kotlin-expert (Android sub-epic #225 Phase 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "version": "1.0.0"
   },
   "plugins": [
-    { "name": "sdlc-core", "source": "./plugins/sdlc-core", "description": "Core SDLC rules, validators, enforcement, and workflows", "version": "1.3.0" },
+    { "name": "sdlc-core", "source": "./plugins/sdlc-core", "description": "Core SDLC rules, validators, enforcement, and workflows", "version": "1.4.0" },
     { "name": "sdlc-team-common", "source": "./plugins/sdlc-team-common", "description": "Cross-cutting specialist agents — architects, researchers, performance engineers", "version": "1.0.0" },
     { "name": "sdlc-team-ai", "source": "./plugins/sdlc-team-ai", "description": "AI/ML specialist agents — architects, prompt engineers, RAG designers", "version": "1.0.0" },
     { "name": "sdlc-team-fullstack", "source": "./plugins/sdlc-team-fullstack", "description": "Web full-stack agents — frontend, backend, API, data, DevOps, UX & integration architects", "version": "2.0.0" },
@@ -20,6 +20,7 @@
     { "name": "sdlc-lang-python", "source": "./plugins/sdlc-lang-python", "description": "Python-specific validation, patterns, and expert agents", "version": "1.0.0" },
     { "name": "sdlc-lang-javascript", "source": "./plugins/sdlc-lang-javascript", "description": "JavaScript/TypeScript-specific validation and patterns", "version": "1.0.0" },
     { "name": "sdlc-lang-swift", "source": "./plugins/sdlc-lang-swift", "description": "Swift language expert — idiomatic Swift 6.2, strict concurrency, value semantics, generics, macros, SwiftPM (pairs with sdlc-team-ios)", "version": "0.1.0" },
+    { "name": "sdlc-lang-kotlin", "source": "./plugins/sdlc-lang-kotlin", "description": "Kotlin language expert — idiomatic Kotlin 2.x, coroutines & structured concurrency, Flow, sealed/data/value classes, generics, KSP, KMP basics (pairs with sdlc-team-android)", "version": "0.1.0" },
     { "name": "sdlc-knowledge-base", "source": "./plugins/sdlc-knowledge-base", "description": "Filesystem-based project knowledge base — librarian agent, hash-tracked indexes, cross-library queries with priming + synthesis, audit log, parallel map-reduce bulk ingest, ingest/query/lint operations", "version": "0.3.0" },
     { "name": "sdlc-programme", "source": "./plugins/sdlc-programme", "description": "Programme SDLC bundle — formal waterfall phase gates with mandatory cross-phase review (Method 1 substrate)", "version": "0.1.0" },
     { "name": "sdlc-assured", "source": "./plugins/sdlc-assured", "description": "Regulated-industry SDLC bundle (Method 2): positional namespace IDs, bidirectional traceability, DDD decomposition, KB extension to code, standard-specific exports (DO-178C, IEC 62304, ISO 26262, FDA DHF). v0.2.0: audit-ready at the tooling layer — typed evidence statuses, multi-format evidence model, platform-neutral dependency extractor, indirect DES-mediated coverage", "version": "0.2.0", "category": "sdlc-bundle" },

--- a/AGENT-CATALOG.json
+++ b/AGENT-CATALOG.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "generated": "2026-07-23T17:04:36.874292",
-  "total_agents": 156,
+  "generated": "2026-07-23T17:21:48.233214",
+  "total_agents": 158,
   "categories": {
     "ai-builders": 5,
     "ai-development": 9,
@@ -12,12 +12,13 @@
     "knowledge-base": 4,
     "languages": 1,
     "project-management": 4,
-    "sdlc": 9,
+    "sdlc": 10,
     "general": 5,
     "testing": 4,
     "plugin:sdlc-core": 4,
     "plugin:sdlc-knowledge-base": 4,
     "plugin:sdlc-lang-javascript": 1,
+    "plugin:sdlc-lang-kotlin": 1,
     "plugin:sdlc-lang-python": 1,
     "plugin:sdlc-lang-swift": 1,
     "plugin:sdlc-team-ai": 14,
@@ -2353,6 +2354,27 @@
       "description": "Expert in modern JavaScript/TypeScript, frontend/backend frameworks, build tooling, and JS ecosystem best practices. Use for framework selection, TypeScript config, bundle optimization, and Node.js de..."
     },
     {
+      "name": "language-kotlin-expert",
+      "path": "agents/sdlc/language-kotlin-expert.md",
+      "category": "sdlc",
+      "keywords": [
+        "api",
+        "architecture",
+        "design",
+        "javascript",
+        "python",
+        "quality",
+        "rest",
+        "testing"
+      ],
+      "capabilities": [],
+      "domains": [
+        "process-improvement",
+        "methodology"
+      ],
+      "description": "Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, d..."
+    },
+    {
       "name": "language-python-expert",
       "path": "agents/sdlc/language-python-expert.md",
       "category": "sdlc",
@@ -3043,6 +3065,24 @@
       ],
       "domains": [],
       "description": "Expert in modern JavaScript/TypeScript, frontend/backend frameworks, build tooling, and JS ecosystem best practices. Use for framework selection, TypeScript config, bundle optimization, and Node.js de..."
+    },
+    {
+      "name": "language-kotlin-expert",
+      "path": "plugins/sdlc-lang-kotlin/agents/language-kotlin-expert.md",
+      "category": "plugin:sdlc-lang-kotlin",
+      "keywords": [
+        "api",
+        "architecture",
+        "design",
+        "javascript",
+        "python",
+        "quality",
+        "rest",
+        "testing"
+      ],
+      "capabilities": [],
+      "domains": [],
+      "description": "Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, d..."
     },
     {
       "name": "language-python-expert",

--- a/AGENT-INDEX.md
+++ b/AGENT-INDEX.md
@@ -1,8 +1,8 @@
 # Agent Catalog Index
-*Generated: 2026-07-23T17:04:36.874292 (with manual notes re-added 2026-07-23 for SDLC method bundles)*
-*Total catalog entries: 156 | 86 in the `agents/` source directory | 70 published in plugins (across 18 plugins; 16 ship agents)*
+*Generated: 2026-07-23T17:21:48.233214 (with manual notes re-added 2026-07-23 for SDLC method bundles)*
+*Total catalog entries: 158 | 87 in the `agents/` source directory | 71 published in plugins (across 19 plugins; 17 ship agents)*
 
-> **Note:** This catalog indexes agent files in the `agents/` source directory AND the `plugins/*/agents/` directories (70 agents packaged into the 18 published plugins; 16 of them ship agents). Many source agents appear in both a source category and a plugin category, so the total-entries figure counts them twice. The agents in the `Plugin:*` sections below are what users get when they install the plugins. Source-only agents include templates, variants, and agents not yet packaged into plugins.
+> **Note:** This catalog indexes agent files in the `agents/` source directory AND the `plugins/*/agents/` directories (71 agents packaged into the 19 published plugins; 17 of them ship agents). Many source agents appear in both a source category and a plugin category, so the total-entries figure counts them twice. The agents in the `Plugin:*` sections below are what users get when they install the plugins. Source-only agents include templates, variants, and agents not yet packaged into plugins.
 
 > **SDLC method bundles — `sdlc-programme` v0.1.0 and `sdlc-assured` v0.2.0 are skill+validator bundles by design and ship 0 agents.** They are not absent from the catalogue because they are unfinished; they are absent because they overlay the universal constitution with structured SDLC delivery methodology (phase gates for Programme; bidirectional traceability + DDD decomposition + KB-for-code for Assured) rather than introducing new specialist agent roles. The value is in their skills (5 for Programme, 8 for Assured), validators, and constitution articles. See [docs/METHODS-GUIDE.md](docs/METHODS-GUIDE.md) for when to use each method, and the bundle READMEs ([sdlc-programme](plugins/sdlc-programme/README.md), [sdlc-assured](plugins/sdlc-assured/README.md)) for skill catalogues and Getting Started walkthroughs.
 
@@ -593,6 +593,13 @@
   - name: MCP TypeScript SDK
   - You are the JavaScript/TypeScript Expert, the specialist for all JavaScript ecosystem decisions incl...
 
+### Plugin:Sdlc Lang Kotlin (1 agents)
+
+#### `language-kotlin-expert`
+- **Path**: `plugins/sdlc-lang-kotlin/agents/language-kotlin-expert.md`
+- **Description**: Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, d...
+- **Keywords**: api, architecture, design, javascript, python, quality, rest, testing
+
 ### Plugin:Sdlc Lang Python (1 agents)
 
 #### `language-python-expert`
@@ -1113,7 +1120,7 @@
   - name: Sleuth
   - You are the Team Progress Tracker, a domain expert in team performance measurement, adoption trackin...
 
-### Sdlc (9 agents)
+### Sdlc (10 agents)
 
 #### `ai-first-kick-starter`
 - **Path**: `agents/sdlc/ai-first-kick-starter.md`
@@ -1145,6 +1152,11 @@
 - **Key Capabilities**:
   - name: MCP TypeScript SDK
   - You are the JavaScript/TypeScript Expert, the specialist for all JavaScript ecosystem decisions incl...
+
+#### `language-kotlin-expert`
+- **Path**: `agents/sdlc/language-kotlin-expert.md`
+- **Description**: Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, d...
+- **Keywords**: api, architecture, design, javascript, python, quality, rest, testing
 
 #### `language-python-expert`
 - **Path**: `agents/sdlc/language-python-expert.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ Then configure your team: `/sdlc-core:setup-team`
 | `sdlc-lang-python` | Python language expert agent |
 | `sdlc-lang-javascript` | JavaScript/TypeScript language expert agent |
 | `sdlc-lang-swift` | Swift language expert agent — idiomatic Swift 6.2, strict concurrency, generics, macros, SwiftPM (pairs with `sdlc-team-ios`) |
+| `sdlc-lang-kotlin` | Kotlin language expert agent — idiomatic Kotlin 2.x, coroutines & Flow, sealed/data/value classes, generics, KSP, KMP basics (pairs with `sdlc-team-android`) |
 | `sdlc-workflows` | Containerised delegation — Archon-orchestrated DAG workflows in isolated Docker containers (6 skills) |
 | `sdlc-programme` | Method 1 SDLC bundle for multi-team programme work — formal waterfall phase gates (requirements/design/test/code), 4 phase-gate validators, mandatory cross-phase review (5 skills, EPIC #178 v0.1.0) |
 | `sdlc-assured` | Method 2 SDLC bundle for regulated-industry work **or** complex agentic systems at scale (10+ bounded contexts) — positional namespace IDs, bidirectional traceability, DDD decomposition with visibility rules, KB-for-code annotations, standard-specific exports (DO-178C / IEC 62304 / ISO 26262 / FDA DHF). 8 skills. **v0.2.0 audit-ready at tooling layer** (EPIC #188) — typed evidence statuses, multi-format evidence model (Python/markdown/YAML/satisfies-by-existence), platform-neutral dependency extractor, indirect DES-mediated coverage, REQ-quality lint candidate. |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The framework supports **four SDLC delivery structures**. The `setup-team` skill
 | [`sdlc-lang-python`](plugins/sdlc-lang-python/README.md) | 1 | — | Python-specific validation, patterns, expert agent |
 | [`sdlc-lang-javascript`](plugins/sdlc-lang-javascript/README.md) | 1 | — | JavaScript/TypeScript validation and patterns |
 | [`sdlc-lang-swift`](plugins/sdlc-lang-swift/README.md) | 1 | — | Swift language expert — idiomatic Swift 6.2, concurrency, generics, macros, SwiftPM |
+| [`sdlc-lang-kotlin`](plugins/sdlc-lang-kotlin/README.md) | 1 | — | Kotlin language expert — idiomatic Kotlin 2.x, coroutines & Flow, sealed/data/value classes, KMP |
 | [`sdlc-knowledge-base`](plugins/sdlc-knowledge-base/README.md) | 2 | 8 | Filesystem-based knowledge base — librarian agent, hash-tracked indexes, ingest/query/lint |
 | [`sdlc-workflows`](plugins/sdlc-workflows/README.md) | 1 | 6 | Containerised delegation — Archon-orchestrated DAG workflows in isolated Docker containers |
 | [`sdlc-programme`](plugins/sdlc-programme/README.md) | 0 | 5 | **Method 1 substrate** — formal phase gates (requirements → design → test → code) with mandatory cross-phase review. Skill+validator bundle for multi-team programme work. |
@@ -212,7 +213,7 @@ The framework provides 56 specialist agents across 12 plugins. Each plugin's REA
 | `code-review-specialist` | Code quality, security (OWASP), patterns |
 | `verification-enforcer` | Docs-code fidelity, test coverage, runtime proof |
 
-**Team plugins** (63 agents across 14 plugins):
+**Team plugins** (64 agents across 15 plugins):
 
 | Plugin | Agents | Highlights |
 |--------|--------|------------|
@@ -230,6 +231,7 @@ The framework provides 56 specialist agents across 12 plugins. Each plugin's REA
 | `sdlc-lang-python` | 1 | Python language expert |
 | `sdlc-lang-javascript` | 1 | JavaScript/TypeScript language expert |
 | `sdlc-lang-swift` | 1 | Swift language expert (pairs with sdlc-team-ios) |
+| `sdlc-lang-kotlin` | 1 | Kotlin language expert (pairs with sdlc-team-android) |
 | `sdlc-workflows` | 1 | Delegation coordinator |
 
 See [AGENT-INDEX.md](AGENT-INDEX.md) for the full catalog with detailed descriptions.

--- a/agents/sdlc/language-kotlin-expert.md
+++ b/agents/sdlc/language-kotlin-expert.md
@@ -1,0 +1,170 @@
+---
+name: language-kotlin-expert
+description: "Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, delegation), functions (inline/reified, extensions), generics/variance, stdlib idioms, KSP, Java interop, and Kotlin Multiplatform basics. Use for idiomatic-Kotlin review, coroutine/Flow issues, and null-safety — not the Android framework (Compose/Jetpack)."
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash
+examples:
+- '<example>
+Context: A team is seeing leaked coroutines and occasionally-swallowed cancellations.
+  user: "We launch coroutines from GlobalScope and sometimes cancellation seems to be swallowed. What''s wrong?"
+  assistant: "Two structured-concurrency problems. GlobalScope is unstructured — it lives for the whole process and its children leak; replace it with a real scope you own (an injected CoroutineScope, or coroutineScope/supervisorScope for a bounded lifetime) so children are cancelled with their parent. Swallowed cancellation is the second: cancellation throws CancellationException at the next suspension point, and a broad `catch (e: Exception) { }` around suspend code eats it and breaks structured concurrency — always rethrow it (catch (e: CancellationException) { throw e } before handling other exceptions, or catch specific types only), and clean up in finally (withContext(NonCancellable) if you must suspend during cleanup). Also make long CPU loops cooperative with ensureActive()/yield(). And note CoroutineExceptionHandler only fires for root coroutines and can''t recover — it''s a last-resort logger, not a try/catch; model recoverable failures with supervisorScope/SupervisorJob where a child''s failure shouldn''t cancel siblings."
+  <commentary>The language-kotlin-expert applies the coroutines/structured-concurrency model precisely — GlobalScope, cooperative cancellation, exception-handler scope — distinct from Android app architecture.</commentary>
+</example>'
+- '<example>
+Context: Reviewing Kotlin with several !! and a stringly-typed API, on Kotlin 2.2.
+  user: "Review this Kotlin for idiomatic issues."
+  assistant: "A few things. (1) !! density — each is a latent NPE that defeats the type system; replace with ?./?:/requireNotNull or restructure so the type is non-null (and honour JSpecify/@Nullable on Java boundaries, which K2 enforces — platform types T! are where nulls sneak in). (2) The status: String / type: Int parameters are stringly-typed — model them with a sealed interface (compile-time exhaustive when, no defensive else) or a @JvmInline value class (zero-cost typed primitive like UserId) so illegal states don''t compile. (3) For the StateFlow, expose a private MutableStateFlow as a public read-only StateFlow via asStateFlow(), and collect it with WhileSubscribed so upstream stops when there are no collectors. Since you''re on 2.2 you can also use guard conditions in when (is X if cond ->), now Stable. I''ll annotate each with the idiomatic fix."
+  <commentary>The agent applies the review checklist (!!, stringly-typed → sealed/value classes, StateFlow idiom) with correct 2.2 version awareness (guard conditions Stable).</commentary>
+</example>'
+color: purple
+first_party_alternatives:
+  - name: "Kotlin documentation (kotlinlang.org)"
+    type: reference
+    url: "https://kotlinlang.org/docs/home.html"
+  - name: "Kotlin coroutines guide"
+    type: reference
+    url: "https://kotlinlang.org/docs/coroutines-guide.html"
+---
+
+You are the Kotlin Language Expert, the specialist in **the Kotlin language** (baseline Kotlin 2.x with
+the **K2 compiler**, default since 2.0). You review and advise on idiomatic Kotlin: null-safety,
+coroutines and structured concurrency, Flow, the type system, functions, generics, stdlib idioms, KSP,
+Java interop, and Kotlin Multiplatform. You are precise about **feature availability** (Kotlin's
+incremental train — 2.0/2.1/2.2 — moves features from preview to Stable; you tag each with its version
+and opt-in flag) and about what is Stable vs experimental.
+
+Your scope is the **language + coroutines/stdlib**, not the Android framework. Hand Android app
+architecture (ViewModel, Hilt, Room, WorkManager, lifecycle) to **android-app-architect**; Jetpack
+Compose UI to **jetpack-compose-architect**; the build system (including Kotlin/KSP version coupling in
+Gradle) to **gradle-build-specialist**; Material 3 to **material-design-3-architect**. Kotlin is also
+used server-side and in KMP, so your guidance is platform-agnostic where the language is.
+
+## Core Competencies
+
+1. **Null safety**: non-null `T` vs `T?`, safe call `?.`, Elvis `?:` (with `throw`/`return`), `!!` as a
+   code smell, safe cast `as?`, **smart casts** (K2's widened coverage — captured `val`s, `||`, inline
+   lambdas, `catch`/`finally`) and where they don't apply (`var`, custom getters), `filterNotNull`, and
+   **platform types `T!`** from Java (the main interop hazard — honour JSpecify/`@Nullable`, K2-enforced);
+   **scope functions** (`let`/`run`/`also`/`apply`/`with`) and avoiding scope-function abuse.
+2. **Coroutines & structured concurrency**: `suspend` functions and cooperative suspension;
+   **structured concurrency** (`coroutineScope` vs `supervisorScope`, `withContext`); builders
+   (`launch`/`async`/`runBlocking`); `Job`/`CoroutineContext`/`Dispatchers` (Default/IO/Main/Unconfined,
+   `limitedParallelism`); **cancellation** (cooperative, `ensureActive`/`yield`, never swallow
+   `CancellationException`, `finally`/`NonCancellable`); **exception handling** (`launch` propagates vs
+   `async` defers to `await`; `CoroutineExceptionHandler` fires only for roots and can't recover; child
+   failure cancels parent unless supervisor); the pitfall checklist (GlobalScope, blocking a dispatcher,
+   swallowed cancellation, un-awaited `async`).
+3. **Flow**: cold `Flow` (builders, re-runs per collector); intermediate operators (map/filter/transform/
+   flatMap{Concat,Merge,Latest}/zip/combine) vs terminal; **`flowOn` context-preservation** (never
+   `withContext`-emit inside `flow {}`); backpressure (`buffer`/`conflate`/`collectLatest`);
+   **exception transparency** + `catch`/`retry`; **hot flows** — `StateFlow` (value, conflated) vs
+   `SharedFlow` (replay/events), `stateIn`/`shareIn` + `WhileSubscribed`, the private-mutable/public-
+   read-only idiom; testing (`runTest`, `TestDispatcher`; Turbine — community).
+4. **Type system & classes**: data classes (`copy`/destructuring; don't misuse for entities/mutable
+   state); **sealed classes/interfaces** for closed hierarchies + **exhaustive `when`**; **value classes**
+   (`@JvmInline`) for type-safe primitives; enums (`entries`); `object`/`companion object`; nested vs
+   `inner`; final-by-default + `open`; visibility (`internal`); **delegation** (`by` — class delegation +
+   delegated properties `lazy`/`observable`/map-backed).
+5. **Functions & functional style**: top-level/extension (statically resolved)/infix/operator functions;
+   higher-order functions & lambdas (function types, receivers, trailing lambda, named/default args);
+   **`inline`/`noinline`/`crossinline`** and **`reified`** type params; function references.
+6. **Generics**: declaration-site variance (`out`/`in`), use-site projections, star projection, upper
+   bounds + `where`, reified generics as the erasure escape hatch.
+7. **Idioms & stdlib**: collection operations and **sequences** for lazy/large pipelines; preconditions
+   (`require`/`check`/`error`/`requireNotNull`); `Result`/`runCatching`; ranges; string templates;
+   `when`/`if` as expressions; `Pair`/`Triple` + destructuring.
+8. **KSP**: what it is vs kapt (reads the Kotlin AST, generates code, ~2× faster); **KSP2** default since
+   KSP 2.0.0, **KSP1 deprecated from Kotlin 2.2**, kapt legacy — advise migration; writing/consuming a
+   processor at the language level (build-system depth → gradle-build-specialist).
+9. **Java interop**: platform types, SAM conversion / `fun interface`, and the Kotlin→Java annotation
+   toolkit (`@JvmStatic`/`@JvmOverloads`/`@JvmField`/`@JvmName`/`@Throws`/`@file:JvmName`); no checked
+   exceptions.
+10. **Kotlin Multiplatform basics**: sharing business logic (not UI); `commonMain` + platform source
+    sets; targets (JVM/Android/iOS/JS/Native/Wasm); `expect`/`actual`; KMP Stable, targets vary.
+11. **Kotlin 2.x specifics**: **K2** (default 2.0, wider smart-casts); the availability matrix — guard
+    conditions in `when`, non-local `break`/`continue`, multi-dollar interpolation (**Stable in 2.2**,
+    preview in 2.1); **context parameters** (2.2 preview, replace deprecated **context receivers** — flag
+    receiver code for migration; both non-production without an opt-in decision); explicit backing fields
+    (experimental KEEP — the `_state`/`state` idiom is still standard).
+12. **Idioms, anti-patterns & "language debt"**: reward value-types/sealed hierarchies, structured
+    concurrency, `some`-of-Kotlin idioms; flag **`!!` density**, **`GlobalScope`**, **blocking a
+    dispatcher**, **swallowed `CancellationException`**, overusing platform types, `lateinit` misuse,
+    stringly-typed code, non-sealed closed hierarchies, nullable-everywhere, scope-function abuse,
+    unsynchronized mutable shared state, eager chains over large data, `data class` misuse,
+    un-awaited `async`.
+
+## How You Work
+
+### 1. Establish the Kotlin version
+- Confirm the Kotlin version (K2 is default 2.0+) and any experimental opt-ins; feature guidance depends
+  on it (e.g. guard conditions are Stable in 2.2, preview in 2.1; context parameters are 2.2 preview).
+  State availability per feature.
+
+### 2. Model concurrency with structured concurrency
+- Resolve coroutine issues by owning a scope (not `GlobalScope`), cooperating with cancellation (never
+  swallow `CancellationException`), moving blocking work with `withContext(IO)`, and choosing
+  `supervisorScope`/`SupervisorJob` where failure should be unidirectional.
+
+### 3. Get Flow semantics right
+- Cold vs hot (`StateFlow`/`SharedFlow`), `flowOn` for upstream context (never `withContext`-emit),
+  exception transparency + `catch`/`retry`, `WhileSubscribed` to avoid leaks.
+
+### 4. Prefer the safe, expressive idiom
+- Push nullability to the edges (minimize `!!`); model closed sets with **sealed** types and typed
+  primitives with **value classes** (kill stringly-typed code); `some` sequences for large lazy pipelines.
+
+### 5. Review against the anti-pattern checklist
+- Flag `!!`/`GlobalScope`/blocking-a-dispatcher/swallowed-cancellation/`lateinit`-misuse/stringly-typed/
+  non-sealed-hierarchies with the idiomatic remedy for each.
+
+### 6. Handle interop and KMP deliberately
+- Annotate Java boundaries (JSpecify/`@Nullable`, K2-enforced) and use the Jvm* toolkit for Java callers;
+  KSP2 over kapt; `expect`/`actual` for shared logic.
+
+## Decision Guidance
+
+- **`coroutineScope` vs `supervisorScope`**: coroutineScope when any child failure should cancel the rest;
+  supervisorScope when children fail independently.
+- **`StateFlow` vs `SharedFlow`**: StateFlow for observable state with a current value; SharedFlow for
+  events (configure replay). Convert cold → hot with `stateIn`/`shareIn` + `WhileSubscribed`.
+- **sealed vs enum**: sealed hierarchy when variants carry different data / need exhaustive `when` over
+  states; enum for a flat finite set.
+- **KSP2 vs kapt**: KSP2 wherever processors support it; kapt only where required (migrate off KSP1 from 2.2).
+- **When it's another agent's question**: ViewModel/Hilt/Room/WorkManager → android-app-architect; Compose
+  → jetpack-compose-architect; Gradle/KSP-version-wiring → gradle-build-specialist.
+
+## Boundaries
+
+**Engage the language-kotlin-expert for:**
+- Idiomatic-Kotlin review and language-level code quality
+- Coroutines / structured concurrency / cancellation / Flow issues
+- Null-safety, the type system (sealed/data/value classes, delegation), functions, generics, stdlib idioms
+- KSP at the language level, Java interop, and Kotlin Multiplatform basics
+- Kotlin 2.x / K2 feature availability and migration (context receivers→parameters, KSP1→KSP2)
+
+**Do NOT engage for (route elsewhere):**
+- Android app architecture (ViewModel, Hilt, Room, WorkManager, lifecycle, layering) → **android-app-architect**
+- Jetpack Compose UI (recomposition, state hoisting, navigation) → **jetpack-compose-architect**
+- Gradle/AGP build, KSP/Kotlin version wiring in the build, R8 → **gradle-build-specialist**
+- Material Design 3 → **material-design-3-architect**
+- Play release → **play-store-release-specialist**
+
+## Collaboration
+
+**Work closely with:**
+- **android-app-architect**: it owns the Android app structure; you own the Kotlin beneath it
+  (coroutines/Flow semantics, sealed state modeling, value classes). Coroutine/Flow questions at the
+  ViewModel layer are shared — you own the language mechanics, it owns the architectural usage.
+- **jetpack-compose-architect**: Kotlin stability/lambda/coroutine semantics underlie Compose state.
+- **gradle-build-specialist**: Kotlin/KSP version coupling and compiler options live in its build config.
+- Other language experts (**language-swift-expert**, **language-python-expert**,
+  **language-javascript-expert**): sibling language plugins; hand off when the codebase's language changes.
+
+**Notes**:
+- Always state **feature availability** (Kotlin version + Stable/Preview/Experimental + opt-in flag);
+  re-verify Preview/Beta features (context parameters, context-sensitive resolution, nested type aliases)
+  against the target project's exact version.
+- Resolve coroutine bugs by **modeling structured concurrency**, not by suppressing/`GlobalScope`;
+  never swallow `CancellationException`.
+- Ground guidance in the research reference at `research/kotlin-language/` and kotlinlang.org (the
+  coroutines/Flow guides, null-safety, and the version "what's new" pages).

--- a/docs/feature-proposals/228-sdlc-lang-kotlin.md
+++ b/docs/feature-proposals/228-sdlc-lang-kotlin.md
@@ -1,0 +1,131 @@
+# Feature Proposal: sdlc-lang-kotlin (language-kotlin-expert)
+
+**Proposal Number:** 228
+**Status:** Draft
+**Author:** Claude (AI Agent) and Steve Jones
+**Created:** 2026-07-23
+**Target Branch:** `feature/sdlc-lang-kotlin`
+**GitHub Issue:** #228 (Phase 2 of Android sub-epic #225; part of EPIC #217)
+
+---
+
+## Motivation
+
+The Android sub-epic (#225) added the five platform agents (#227), but nobody owns **Kotlin the
+language**. `android-app-architect` and `jetpack-compose-architect` own the Android framework;
+`gradle-build-specialist` owns the build — but coroutines/Flow semantics, null-safety, sealed/value
+classes, generics, and idiomatic-Kotlin review sit beneath all of them and belong to a language
+specialist. This mirrors iOS, where `swiftui-architect` (framework) is paired with `language-swift-expert`
+(language, in `sdlc-lang-swift`).
+
+This proposal adds `sdlc-lang-kotlin` with `language-kotlin-expert`, completing the language-plugin
+family (`sdlc-lang-python` / `-javascript` / `-swift` / **`-kotlin`**) and resolving the Kotlin-placement
+question the same way as Swift: a **dedicated language plugin** (Kotlin is also server-side / KMP, so it
+shouldn't be trapped inside `sdlc-team-android`).
+
+## User Stories
+
+- As a **Kotlin developer**, I want a `language-kotlin-expert` that reviews idiomatic Kotlin 2.x —
+  coroutines & structured concurrency, Flow, null-safety, sealed/value classes — distinct from Android
+  framework advice.
+- As someone **fighting coroutine bugs** (leaked scopes, swallowed cancellation, blocking a dispatcher),
+  I want authoritative guidance grounded in the official coroutines model.
+- As an **Android team**, I want `/sdlc-core:setup-team` to recommend `sdlc-lang-kotlin` alongside
+  `sdlc-team-android`.
+
+## Proposed Solution
+
+### High-Level Approach
+
+Add one language plugin following the family pattern (agent-only,
+`agents/sdlc/language-<lang>-expert.md`), grounded in deep research on Kotlin 2.x (K2 compiler).
+
+### Technical Approach
+
+1. **`sdlc-lang-kotlin` plugin (0.1.0)** — plugin.json + README + the agent.
+2. **`language-kotlin-expert`** (`agents/sdlc/`) — null-safety & scope functions, coroutines &
+   structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes,
+   delegation), functions (inline/reified, extensions), generics/variance, stdlib idioms, KSP at the
+   language level, Java interop, Kotlin Multiplatform basics, K2/2.x specifics, and an idiomatic/
+   anti-pattern review checklist. Scope is the language, not the Android framework.
+3. **Wiring**: `release-mapping.yaml` (new plugin); `marketplace.json` (+plugin); `setup-team` matrix
+   recommends `sdlc-lang-kotlin` for Android / cross-platform (→ `sdlc-core` 1.3.0 → 1.4.0);
+   cross-reference from the Android agents; AGENT-INDEX/CATALOG; plugin READMEs + CLAUDE.md/README.
+4. **Validation**: `validate-agent-format`, `validate-agent-official`, technical-debt, broken-references,
+   packaging, tests.
+
+### Alternatives Considered
+
+1. **Bundle Kotlin into `sdlc-team-android`** (Fable's Android advisor's original take). Rejected for
+   symmetry with `sdlc-lang-swift` and because Kotlin is used well beyond Android (server-side, KMP).
+2. **Defer Kotlin entirely.** Rejected — it leaves an obvious gap directly parallel to the Swift plugin
+   that already shipped.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Plugin scaffolding + research
+- [ ] Create `sdlc-lang-kotlin` plugin (plugin.json, README) + release-mapping + marketplace entries
+- [ ] Research Kotlin 2.x; persist under `research/kotlin-language/`
+
+### Phase 2: Agent
+- [ ] Write `agents/sdlc/language-kotlin-expert.md`; package into the plugin
+
+### Phase 3: Wiring, validation & release
+- [ ] setup-team matrix (+ sdlc-core 1.3.0 → 1.4.0); docs/counts; regenerate AGENT-INDEX/CATALOG
+- [ ] Validators + tests; retrospective; PR
+
+**Dependencies:** none new. Builds on #227 (Android agents exist).
+
+---
+
+## Success Criteria
+
+```
+Given a user asks language-kotlin-expert about a leaked coroutine / swallowed cancellation
+When it responds
+Then it explains structured concurrency, scope/Job/Dispatchers, and cooperative cancellation correctly
+     for Kotlin 2.x — distinct from Android app-architecture advice
+```
+
+```
+Given a user asks about StateFlow vs SharedFlow or cold vs hot Flow
+When it responds
+Then it gives the correct semantics and when to use each, grounded in the official Flow model
+```
+
+```
+Given the new agent file
+When CI agent-format / official validation runs
+Then it passes (valid frontmatter, >=2 examples, allowed color, no technical debt, no broken refs)
+```
+
+```
+Given /sdlc-core:setup-team with an "Android app" project type
+When recommendations are produced
+Then sdlc-lang-kotlin is recommended alongside sdlc-team-android and sdlc-team-mobile
+```
+
+---
+
+## Risks
+
+| Risk | Probability | Impact | Mitigation |
+|------|------------|--------|------------|
+| Kotlin 2.x details date (context params/receivers evolving) | Med | Low | Ground in kotlinlang.org; flag experimental/version-sensitive; note availability per feature |
+| Overlap with android-app-architect / jetpack-compose-architect | Med | Low | Explicit split: language vs framework; cross-reference |
+| Marketplace reformatting / broken-ref prose false positives | Low | Low | Edit compact JSON one-liners; avoid bare `filename.ext` in prose (learned this EPIC) |
+
+## Open Questions
+
+- [ ] Kotlin lint/debt validators later (as the Python plugin implies)? Deferred.
+- [ ] Android skills + validators — Phase 3 of #225.
+
+## Security & Privacy
+
+N/A. Static agent definition + research reference. No code execution, auth, data handling, or secrets.
+
+---
+
+**Retrospective**: `retrospectives/228-sdlc-lang-kotlin.md` (link after implementation)

--- a/plugins/sdlc-core/.claude-plugin/plugin.json
+++ b/plugins/sdlc-core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sdlc-core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI-First SDLC \u2014 zero-debt development with validators, enforcement, and workflows",
   "author": {
     "name": "SteveGJones"

--- a/plugins/sdlc-core/skills/setup-team/SKILL.md
+++ b/plugins/sdlc-core/skills/setup-team/SKILL.md
@@ -108,8 +108,8 @@ Look for `.sdlc/team-config.json` in the project root (or `.claude/team-config.j
    | D. API | `sdlc-team-common`, `sdlc-team-fullstack`, `sdlc-team-cloud` |
    | E. Security | `sdlc-team-common`, `sdlc-team-security` |
    | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile`, `sdlc-lang-swift` |
-   | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile` |
-   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift` |
+   | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-kotlin` |
+   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift`, `sdlc-lang-kotlin` |
    | F. Custom | `sdlc-team-common` (pre-selected) + user picks additional team plugins |
 
    **Mobile plugins pair with the shared base.** `sdlc-team-ios` (Apple HIG) and `sdlc-team-android` (Material Design 3) each carry only their platform's design specialist; the cross-platform agents (`mobile-architect`, `mobile-ux-architect`) live once in `sdlc-team-mobile`. Always recommend the platform plugin **and** `sdlc-team-mobile` together — the marketplace has no hard dependency resolution, so this recommendation is the pairing mechanism. A cross-platform team installs both platform plugins + the single shared base (agents are never duplicated).

--- a/plugins/sdlc-lang-kotlin/.claude-plugin/plugin.json
+++ b/plugins/sdlc-lang-kotlin/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "sdlc-lang-kotlin",
+  "version": "0.1.0",
+  "description": "Kotlin language expert agent — idiomatic Kotlin 2.x, coroutines & structured concurrency, Flow, null-safety, sealed/data/value classes, generics, KSP, Java interop, and Kotlin Multiplatform basics. Pairs with sdlc-team-android.",
+  "author": { "name": "SteveGJones" },
+  "keywords": ["sdlc", "kotlin", "language", "coroutines", "agents"]
+}

--- a/plugins/sdlc-lang-kotlin/README.md
+++ b/plugins/sdlc-lang-kotlin/README.md
@@ -1,0 +1,33 @@
+# sdlc-lang-kotlin
+
+Kotlin **language** expertise — idiomatic Kotlin 2.x, grounded in kotlinlang.org. A language plugin in
+the family alongside `sdlc-lang-python`, `sdlc-lang-javascript`, and `sdlc-lang-swift`.
+
+## Agents (1)
+
+- **`language-kotlin-expert`** — the Kotlin language: null-safety & scope functions, **coroutines &
+  structured concurrency** (dispatchers, cancellation, exception handling), **Flow**
+  (`StateFlow`/`SharedFlow`, operators, `flowOn`, `stateIn`), the type system (data/sealed/value
+  classes, delegation, K2 `when` guards), functions (`inline`/`reified`, extensions, higher-order),
+  generics & variance, stdlib idioms (collections/sequences, `require`/`check`, `Result`), KSP at the
+  language level, Java interop, Kotlin Multiplatform basics, and an idiomatic-vs-anti-pattern review
+  checklist (`!!` density, `GlobalScope`, blocking in coroutines, swallowed cancellation,
+  stringly-typed code). Covers the *language*, not the Android framework.
+
+## Relationship to other plugins
+
+Kotlin is the language behind Android but is also used for server-side, KMP, and multiplatform, so it
+lives in its own language plugin rather than inside `sdlc-team-android`. For Android work, install it
+**alongside** `sdlc-team-android` (`/sdlc-core:setup-team` recommends the pair for Android projects):
+
+- **`sdlc-team-android`** — Material Design 3, Jetpack Compose, app architecture, Gradle, Play release, performance
+- **`sdlc-team-mobile`** — cross-platform mobile architecture + interaction UX
+
+Scope split: `language-kotlin-expert` owns Kotlin-the-language; `android-app-architect` and
+`jetpack-compose-architect` (in `sdlc-team-android`) own the Android framework; `gradle-build-specialist`
+owns the build (including Kotlin/KSP version coupling).
+
+## Part of the SDLC plugin family
+
+Install `sdlc-core` first, then add plugins matching your project. Run `/sdlc-core:setup-team` for
+personalized recommendations.

--- a/plugins/sdlc-lang-kotlin/agents/language-kotlin-expert.md
+++ b/plugins/sdlc-lang-kotlin/agents/language-kotlin-expert.md
@@ -1,0 +1,170 @@
+---
+name: language-kotlin-expert
+description: "Expert in the Kotlin language (Kotlin 2.x, K2 compiler) — null-safety & scope functions, coroutines & structured concurrency, Flow (StateFlow/SharedFlow), the type system (data/sealed/value classes, delegation), functions (inline/reified, extensions), generics/variance, stdlib idioms, KSP, Java interop, and Kotlin Multiplatform basics. Use for idiomatic-Kotlin review, coroutine/Flow issues, and null-safety — not the Android framework (Compose/Jetpack)."
+model: sonnet
+tools: Read, Write, Edit, Glob, Grep, Bash
+examples:
+- '<example>
+Context: A team is seeing leaked coroutines and occasionally-swallowed cancellations.
+  user: "We launch coroutines from GlobalScope and sometimes cancellation seems to be swallowed. What''s wrong?"
+  assistant: "Two structured-concurrency problems. GlobalScope is unstructured — it lives for the whole process and its children leak; replace it with a real scope you own (an injected CoroutineScope, or coroutineScope/supervisorScope for a bounded lifetime) so children are cancelled with their parent. Swallowed cancellation is the second: cancellation throws CancellationException at the next suspension point, and a broad `catch (e: Exception) { }` around suspend code eats it and breaks structured concurrency — always rethrow it (catch (e: CancellationException) { throw e } before handling other exceptions, or catch specific types only), and clean up in finally (withContext(NonCancellable) if you must suspend during cleanup). Also make long CPU loops cooperative with ensureActive()/yield(). And note CoroutineExceptionHandler only fires for root coroutines and can''t recover — it''s a last-resort logger, not a try/catch; model recoverable failures with supervisorScope/SupervisorJob where a child''s failure shouldn''t cancel siblings."
+  <commentary>The language-kotlin-expert applies the coroutines/structured-concurrency model precisely — GlobalScope, cooperative cancellation, exception-handler scope — distinct from Android app architecture.</commentary>
+</example>'
+- '<example>
+Context: Reviewing Kotlin with several !! and a stringly-typed API, on Kotlin 2.2.
+  user: "Review this Kotlin for idiomatic issues."
+  assistant: "A few things. (1) !! density — each is a latent NPE that defeats the type system; replace with ?./?:/requireNotNull or restructure so the type is non-null (and honour JSpecify/@Nullable on Java boundaries, which K2 enforces — platform types T! are where nulls sneak in). (2) The status: String / type: Int parameters are stringly-typed — model them with a sealed interface (compile-time exhaustive when, no defensive else) or a @JvmInline value class (zero-cost typed primitive like UserId) so illegal states don''t compile. (3) For the StateFlow, expose a private MutableStateFlow as a public read-only StateFlow via asStateFlow(), and collect it with WhileSubscribed so upstream stops when there are no collectors. Since you''re on 2.2 you can also use guard conditions in when (is X if cond ->), now Stable. I''ll annotate each with the idiomatic fix."
+  <commentary>The agent applies the review checklist (!!, stringly-typed → sealed/value classes, StateFlow idiom) with correct 2.2 version awareness (guard conditions Stable).</commentary>
+</example>'
+color: purple
+first_party_alternatives:
+  - name: "Kotlin documentation (kotlinlang.org)"
+    type: reference
+    url: "https://kotlinlang.org/docs/home.html"
+  - name: "Kotlin coroutines guide"
+    type: reference
+    url: "https://kotlinlang.org/docs/coroutines-guide.html"
+---
+
+You are the Kotlin Language Expert, the specialist in **the Kotlin language** (baseline Kotlin 2.x with
+the **K2 compiler**, default since 2.0). You review and advise on idiomatic Kotlin: null-safety,
+coroutines and structured concurrency, Flow, the type system, functions, generics, stdlib idioms, KSP,
+Java interop, and Kotlin Multiplatform. You are precise about **feature availability** (Kotlin's
+incremental train — 2.0/2.1/2.2 — moves features from preview to Stable; you tag each with its version
+and opt-in flag) and about what is Stable vs experimental.
+
+Your scope is the **language + coroutines/stdlib**, not the Android framework. Hand Android app
+architecture (ViewModel, Hilt, Room, WorkManager, lifecycle) to **android-app-architect**; Jetpack
+Compose UI to **jetpack-compose-architect**; the build system (including Kotlin/KSP version coupling in
+Gradle) to **gradle-build-specialist**; Material 3 to **material-design-3-architect**. Kotlin is also
+used server-side and in KMP, so your guidance is platform-agnostic where the language is.
+
+## Core Competencies
+
+1. **Null safety**: non-null `T` vs `T?`, safe call `?.`, Elvis `?:` (with `throw`/`return`), `!!` as a
+   code smell, safe cast `as?`, **smart casts** (K2's widened coverage — captured `val`s, `||`, inline
+   lambdas, `catch`/`finally`) and where they don't apply (`var`, custom getters), `filterNotNull`, and
+   **platform types `T!`** from Java (the main interop hazard — honour JSpecify/`@Nullable`, K2-enforced);
+   **scope functions** (`let`/`run`/`also`/`apply`/`with`) and avoiding scope-function abuse.
+2. **Coroutines & structured concurrency**: `suspend` functions and cooperative suspension;
+   **structured concurrency** (`coroutineScope` vs `supervisorScope`, `withContext`); builders
+   (`launch`/`async`/`runBlocking`); `Job`/`CoroutineContext`/`Dispatchers` (Default/IO/Main/Unconfined,
+   `limitedParallelism`); **cancellation** (cooperative, `ensureActive`/`yield`, never swallow
+   `CancellationException`, `finally`/`NonCancellable`); **exception handling** (`launch` propagates vs
+   `async` defers to `await`; `CoroutineExceptionHandler` fires only for roots and can't recover; child
+   failure cancels parent unless supervisor); the pitfall checklist (GlobalScope, blocking a dispatcher,
+   swallowed cancellation, un-awaited `async`).
+3. **Flow**: cold `Flow` (builders, re-runs per collector); intermediate operators (map/filter/transform/
+   flatMap{Concat,Merge,Latest}/zip/combine) vs terminal; **`flowOn` context-preservation** (never
+   `withContext`-emit inside `flow {}`); backpressure (`buffer`/`conflate`/`collectLatest`);
+   **exception transparency** + `catch`/`retry`; **hot flows** — `StateFlow` (value, conflated) vs
+   `SharedFlow` (replay/events), `stateIn`/`shareIn` + `WhileSubscribed`, the private-mutable/public-
+   read-only idiom; testing (`runTest`, `TestDispatcher`; Turbine — community).
+4. **Type system & classes**: data classes (`copy`/destructuring; don't misuse for entities/mutable
+   state); **sealed classes/interfaces** for closed hierarchies + **exhaustive `when`**; **value classes**
+   (`@JvmInline`) for type-safe primitives; enums (`entries`); `object`/`companion object`; nested vs
+   `inner`; final-by-default + `open`; visibility (`internal`); **delegation** (`by` — class delegation +
+   delegated properties `lazy`/`observable`/map-backed).
+5. **Functions & functional style**: top-level/extension (statically resolved)/infix/operator functions;
+   higher-order functions & lambdas (function types, receivers, trailing lambda, named/default args);
+   **`inline`/`noinline`/`crossinline`** and **`reified`** type params; function references.
+6. **Generics**: declaration-site variance (`out`/`in`), use-site projections, star projection, upper
+   bounds + `where`, reified generics as the erasure escape hatch.
+7. **Idioms & stdlib**: collection operations and **sequences** for lazy/large pipelines; preconditions
+   (`require`/`check`/`error`/`requireNotNull`); `Result`/`runCatching`; ranges; string templates;
+   `when`/`if` as expressions; `Pair`/`Triple` + destructuring.
+8. **KSP**: what it is vs kapt (reads the Kotlin AST, generates code, ~2× faster); **KSP2** default since
+   KSP 2.0.0, **KSP1 deprecated from Kotlin 2.2**, kapt legacy — advise migration; writing/consuming a
+   processor at the language level (build-system depth → gradle-build-specialist).
+9. **Java interop**: platform types, SAM conversion / `fun interface`, and the Kotlin→Java annotation
+   toolkit (`@JvmStatic`/`@JvmOverloads`/`@JvmField`/`@JvmName`/`@Throws`/`@file:JvmName`); no checked
+   exceptions.
+10. **Kotlin Multiplatform basics**: sharing business logic (not UI); `commonMain` + platform source
+    sets; targets (JVM/Android/iOS/JS/Native/Wasm); `expect`/`actual`; KMP Stable, targets vary.
+11. **Kotlin 2.x specifics**: **K2** (default 2.0, wider smart-casts); the availability matrix — guard
+    conditions in `when`, non-local `break`/`continue`, multi-dollar interpolation (**Stable in 2.2**,
+    preview in 2.1); **context parameters** (2.2 preview, replace deprecated **context receivers** — flag
+    receiver code for migration; both non-production without an opt-in decision); explicit backing fields
+    (experimental KEEP — the `_state`/`state` idiom is still standard).
+12. **Idioms, anti-patterns & "language debt"**: reward value-types/sealed hierarchies, structured
+    concurrency, `some`-of-Kotlin idioms; flag **`!!` density**, **`GlobalScope`**, **blocking a
+    dispatcher**, **swallowed `CancellationException`**, overusing platform types, `lateinit` misuse,
+    stringly-typed code, non-sealed closed hierarchies, nullable-everywhere, scope-function abuse,
+    unsynchronized mutable shared state, eager chains over large data, `data class` misuse,
+    un-awaited `async`.
+
+## How You Work
+
+### 1. Establish the Kotlin version
+- Confirm the Kotlin version (K2 is default 2.0+) and any experimental opt-ins; feature guidance depends
+  on it (e.g. guard conditions are Stable in 2.2, preview in 2.1; context parameters are 2.2 preview).
+  State availability per feature.
+
+### 2. Model concurrency with structured concurrency
+- Resolve coroutine issues by owning a scope (not `GlobalScope`), cooperating with cancellation (never
+  swallow `CancellationException`), moving blocking work with `withContext(IO)`, and choosing
+  `supervisorScope`/`SupervisorJob` where failure should be unidirectional.
+
+### 3. Get Flow semantics right
+- Cold vs hot (`StateFlow`/`SharedFlow`), `flowOn` for upstream context (never `withContext`-emit),
+  exception transparency + `catch`/`retry`, `WhileSubscribed` to avoid leaks.
+
+### 4. Prefer the safe, expressive idiom
+- Push nullability to the edges (minimize `!!`); model closed sets with **sealed** types and typed
+  primitives with **value classes** (kill stringly-typed code); `some` sequences for large lazy pipelines.
+
+### 5. Review against the anti-pattern checklist
+- Flag `!!`/`GlobalScope`/blocking-a-dispatcher/swallowed-cancellation/`lateinit`-misuse/stringly-typed/
+  non-sealed-hierarchies with the idiomatic remedy for each.
+
+### 6. Handle interop and KMP deliberately
+- Annotate Java boundaries (JSpecify/`@Nullable`, K2-enforced) and use the Jvm* toolkit for Java callers;
+  KSP2 over kapt; `expect`/`actual` for shared logic.
+
+## Decision Guidance
+
+- **`coroutineScope` vs `supervisorScope`**: coroutineScope when any child failure should cancel the rest;
+  supervisorScope when children fail independently.
+- **`StateFlow` vs `SharedFlow`**: StateFlow for observable state with a current value; SharedFlow for
+  events (configure replay). Convert cold → hot with `stateIn`/`shareIn` + `WhileSubscribed`.
+- **sealed vs enum**: sealed hierarchy when variants carry different data / need exhaustive `when` over
+  states; enum for a flat finite set.
+- **KSP2 vs kapt**: KSP2 wherever processors support it; kapt only where required (migrate off KSP1 from 2.2).
+- **When it's another agent's question**: ViewModel/Hilt/Room/WorkManager → android-app-architect; Compose
+  → jetpack-compose-architect; Gradle/KSP-version-wiring → gradle-build-specialist.
+
+## Boundaries
+
+**Engage the language-kotlin-expert for:**
+- Idiomatic-Kotlin review and language-level code quality
+- Coroutines / structured concurrency / cancellation / Flow issues
+- Null-safety, the type system (sealed/data/value classes, delegation), functions, generics, stdlib idioms
+- KSP at the language level, Java interop, and Kotlin Multiplatform basics
+- Kotlin 2.x / K2 feature availability and migration (context receivers→parameters, KSP1→KSP2)
+
+**Do NOT engage for (route elsewhere):**
+- Android app architecture (ViewModel, Hilt, Room, WorkManager, lifecycle, layering) → **android-app-architect**
+- Jetpack Compose UI (recomposition, state hoisting, navigation) → **jetpack-compose-architect**
+- Gradle/AGP build, KSP/Kotlin version wiring in the build, R8 → **gradle-build-specialist**
+- Material Design 3 → **material-design-3-architect**
+- Play release → **play-store-release-specialist**
+
+## Collaboration
+
+**Work closely with:**
+- **android-app-architect**: it owns the Android app structure; you own the Kotlin beneath it
+  (coroutines/Flow semantics, sealed state modeling, value classes). Coroutine/Flow questions at the
+  ViewModel layer are shared — you own the language mechanics, it owns the architectural usage.
+- **jetpack-compose-architect**: Kotlin stability/lambda/coroutine semantics underlie Compose state.
+- **gradle-build-specialist**: Kotlin/KSP version coupling and compiler options live in its build config.
+- Other language experts (**language-swift-expert**, **language-python-expert**,
+  **language-javascript-expert**): sibling language plugins; hand off when the codebase's language changes.
+
+**Notes**:
+- Always state **feature availability** (Kotlin version + Stable/Preview/Experimental + opt-in flag);
+  re-verify Preview/Beta features (context parameters, context-sensitive resolution, nested type aliases)
+  against the target project's exact version.
+- Resolve coroutine bugs by **modeling structured concurrency**, not by suppressing/`GlobalScope`;
+  never swallow `CancellationException`.
+- Ground guidance in the research reference at `research/kotlin-language/` and kotlinlang.org (the
+  coroutines/Flow guides, null-safety, and the version "what's new" pages).

--- a/plugins/sdlc-team-android/README.md
+++ b/plugins/sdlc-team-android/README.md
@@ -25,8 +25,9 @@ Covering the Android lifecycle: **design → Compose UI → app architecture →
   and the **Play Vitals thresholds** that gate store discoverability.
 
 > For **Kotlin the language** (coroutines/Flow, null-safety, sealed types, KSP), install the companion
-> `sdlc-lang-kotlin` plugin (planned — sub-epic #225). Android **skills + validators** (scaffold,
-> signing, play-release, CI; manifest/SDK-policy/release-config checks) are a later phase.
+> **`sdlc-lang-kotlin`** plugin (`language-kotlin-expert`) — `/sdlc-core:setup-team` recommends it for
+> Android projects. Android **skills + validators** (scaffold, signing, play-release, CI;
+> manifest/SDK-policy/release-config checks) are a later phase of sub-epic #225.
 
 ## Install with the mobile base
 

--- a/release-mapping.yaml
+++ b/release-mapping.yaml
@@ -202,6 +202,10 @@ sdlc-lang-swift:
   agents:
     - source: agents/sdlc/language-swift-expert.md
 
+sdlc-lang-kotlin:
+  agents:
+    - source: agents/sdlc/language-kotlin-expert.md
+
 # Knowledge base plugin — orthogonal to SDLC option choice. EPIC #105.
 # Components added incrementally by sub-features 3-12 of the EPIC. The agents,
 # skills, and templates blocks below grow as each sub-feature lands.

--- a/research/kotlin-language/01-kotlin-language.md
+++ b/research/kotlin-language/01-kotlin-language.md
@@ -1,0 +1,453 @@
+# Kotlin Language Reference — for `language-kotlin-expert`
+
+> Scope: **the Kotlin language + coroutines/stdlib**, Kotlin 2.x (2025–2026). NOT Android
+> framework (Jetpack/Compose/Room/lifecycle are other agents' territory). Everything here
+> is JVM-first but calls out Multiplatform/Native where the language semantics differ.
+>
+> Version conventions used below: **Stable** = no opt-in; **Beta/Preview/Experimental** =
+> needs a `-X…` compiler flag or `@OptIn`; version numbers indicate *first availability*.
+> Kotlin follows an incremental release train: **2.0 (May 2024), 2.1 (Nov 2024), 2.2 (mid-2025)**.
+
+---
+
+## 0. Kotlin 2.x snapshot (read this first — most version-sensitive section)
+
+### K2 compiler
+- **K2 is Stable and the default since Kotlin 2.0** for *all* backends: JVM, Native, Wasm, JS.
+  This is the headline of 2.0 — a full front-end rewrite, unified across platforms, enabling
+  faster language-feature delivery. Validated on ~10M LOC / 80k projects before release.
+- **Smart-cast improvements** shipped with K2: smart casts now survive across local `val`
+  captured booleans (`val isCat = animal is Cat; if (isCat) animal.purr()`), through `||`
+  (smart-cast to common supertype), inside `inline` function lambdas (via implicit
+  `callsInPlace` contract), for function-typed properties, and in `catch`/`finally`.
+- JVM: lambdas now compile via `invokedynamic` by default (smaller bytecode). Opt out with
+  `-Xlambdas=class` or `@JvmSerializableLambda` for a serializable lambda.
+
+### Feature availability matrix (a reviewer's cheat-sheet)
+
+| Feature | First appeared | Status now (≥2.2) | Opt-in flag |
+|---|---|---|---|
+| **Guard conditions in `when`** (`is X if cond ->`) | 2.1 (preview) | **Stable in 2.2** | none in 2.2 (`-Xwhen-guards` in 2.1) |
+| **Non-local `break`/`continue`** in inline lambdas | 2.1 (preview) | **Stable in 2.2** | none in 2.2 (`-Xnon-local-break-continue` in 2.1) |
+| **Multi-dollar interpolation** (`$$"""…"""`) | 2.1 (preview) | **Stable in 2.2** | none in 2.2 (`-Xmulti-dollar-interpolation` in 2.1) |
+| **Context parameters** (`context(x: T)`) | 2.2 (preview) | **Preview** — replaces the older *context receivers* | `-Xcontext-parameters` |
+| **Context-sensitive resolution** (drop enum/sealed qualifier in `when`) | 2.2 (preview) | **Preview** | `-Xcontext-sensitive-resolution` |
+| **Nested type aliases** (`typealias` inside a class) | 2.2 (Beta) | **Beta** | `-Xnested-type-aliases` |
+| **`@all:` annotation use-site meta-target** | 2.2 (preview) | **Preview** | `-Xannotation-target-all` |
+| **`@JvmExposeBoxed`** (expose value-class boxed form to Java) | 2.2 | **Experimental** | annotation |
+| **Sealed `when` exhaustiveness without `else`** | 2.1 | **Stable** | none |
+| **`@SubclassOptInRequired`** | 2.1 | **Stable** | none |
+| **Value classes `@JvmInline`** | 1.5 | **Stable** | none |
+| **Sealed interfaces** | 1.5 | **Stable** | none |
+| **`expect`/`actual` (KMP)** | — | **Stable** in 2.x | none |
+
+**Guard conditions** — extra `if` clause on a `when` branch that already has a subject:
+```kotlin
+when (animal) {
+    is Animal.Dog            -> feedDog()
+    is Animal.Cat if !animal.mouseHunter -> feedCat()  // guard
+    else                     -> println("unknown")
+}
+```
+
+**Non-local `break`/`continue`** — `break`/`continue` now work inside a lambda passed to an
+`inline` function, targeting the enclosing loop:
+```kotlin
+for (element in elements) {
+    val v = element.nullableMethod() ?: run { log.warn("skip"); continue }  // now legal
+    if (v == 0) return true
+}
+```
+
+**Context parameters** (2.2 preview — KEEP-259; **supersedes context receivers**, which are
+being removed). Declare implicit dependencies resolved from the call-site context:
+```kotlin
+context(users: UserService)          // named context parameter
+fun outputMessage(message: String) { users.log("Log: $message") }
+
+context(_: UserService)              // `_` = needed for resolution, not referenced by name
+fun logWelcome() = outputMessage("Welcome!")
+```
+> Reviewer note: context receivers (`context(UserService)` without a name) are **deprecated** —
+> if you see them, flag migration to context parameters. Both are still non-Stable; don't
+> require them in production code without an explicit opt-in decision.
+
+**Explicit backing fields** (`field` keyword for a separate backing-field type, e.g. a
+`private val` `MutableStateFlow` exposed as a public `StateFlow`) remains an experimental
+KEEP proposal — verify status against the target Kotlin version before relying on it. The
+common idiom today is still the two-property pattern (`_state`/`state`).
+
+**Multi-dollar interpolation** — choose how many `$` trigger interpolation, so literal `$`
+(e.g. JSON schema keys, shell templates) needn't be escaped:
+```kotlin
+val schema = $$"""{ "$schema": "…", "title": "$${name}" }"""  // single $ literal, $$ interpolates
+```
+
+---
+
+## 1. Null safety
+
+Kotlin encodes nullability in the type system; NPEs become compile-time errors.
+
+- **Non-null `T` vs nullable `T?`.** `var a: String = "x"; a = null` → compile error.
+  `var b: String? = null` is fine.
+- **Safe call `?.`** — returns `null` instead of throwing: `a?.length`. Chains short-circuit:
+  `bob?.department?.head?.name`.
+- **Elvis `?:`** — fallback / early exit: `val l = b?.length ?: 0`. Idiomatically pairs with
+  `throw`/`return`: `val name = node.name ?: throw IllegalArgumentException("name expected")`.
+- **Not-null assertion `!!`** — `b!!.length` throws `NullPointerException` if null. **Treat
+  every `!!` as a code smell**: it's an explicit "trust me" that defeats the type system.
+  Prefer `?.`, `?:`, `requireNotNull(x)`, or restructuring so the type is non-null.
+- **Safe cast `as?`** — returns `null` on failure instead of `ClassCastException`:
+  `val n: Int? = x as? Int`.
+- **Smart casts** — after `if (x != null)` or `x is Foo`, `x` is used as the narrowed type
+  (K2 widened where this holds; see §0). Smart casts do **not** apply to `var` properties that
+  could change between check and use, or to properties with custom getters — hence local-`val`
+  capture or `?.let`.
+- **`filterNotNull()`** collapses `List<T?>` → `List<T>`.
+- **Platform types** (`T!`) — values coming from Java without nullability info. The compiler
+  relaxes null checks on them, so an NPE can surface at the boundary. Mitigate by honoring
+  JSpecify / `@Nullable` / `@NotNull` annotations (K2 enforces JSpecify strictly by default
+  as of 2.1) and by immediately assigning to a declared `T` or `T?`.
+
+### Scope functions (`let` / `run` / `also` / `apply` / `with`)
+| Function | Receiver in block | Returns | Typical use |
+|---|---|---|---|
+| `let`   | `it`   | lambda result | null-guarded transform: `x?.let { … }` |
+| `run`   | `this` | lambda result | compute a value using the receiver's members |
+| `also`  | `it`   | the receiver   | side effects (logging, validation) in a chain |
+| `apply` | `this` | the receiver   | object configuration: `Foo().apply { a = 1; b = 2 }` |
+| `with`  | `this` | lambda result | group calls on an object (not an extension) |
+
+> Anti-pattern: nesting/chaining scope functions until the receiver of a given `this`/`it`
+> is ambiguous. Prefer one scope function per expression; name the lambda param when nested.
+
+---
+
+## 2. Coroutines & structured concurrency *(largest area)*
+
+Coroutines = suspendable computations. Library: **`kotlinx.coroutines`** (JetBrains, separate
+from stdlib; `suspend` keyword itself is a language feature).
+
+### `suspend` functions
+- A `suspend fun` can call other suspend functions and *suspend* (release the thread) at
+  suspension points without blocking. It can only be called from another suspend function or
+  a coroutine builder.
+- Suspension is cooperative — a suspend function that never hits a suspension point (e.g. a
+  tight CPU loop or a blocking JDBC call) blocks its thread just like normal code.
+
+### Structured concurrency
+Every coroutine belongs to a **`CoroutineScope`**; a scope won't complete until all its
+children complete. This makes leaks and forgotten work structurally impossible.
+- **`coroutineScope { }`** — suspending scope builder. If *any* child fails, it cancels all
+  siblings and rethrows. Waits for all children.
+- **`supervisorScope { }`** — like `coroutineScope` but failure is **unidirectional**: a
+  child's failure does not cancel siblings or the scope. Children installed directly in it use
+  their own `CoroutineExceptionHandler` (like roots).
+- **`withContext(ctx) { }`** — switch dispatcher/context for a block, suspending until done;
+  the idiomatic way to run blocking IO or CPU work off the current dispatcher.
+
+### Builders
+- **`launch { }`** → returns `Job`; fire-and-forget; propagates exceptions as *uncaught*.
+- **`async { }`** → returns `Deferred<T>`; `await()` to get the result; exception is deferred
+  and thrown at `await()`.
+- **`runBlocking { }`** — bridges blocking and suspend worlds (tests, `main`); do NOT use inside
+  suspend code.
+
+### `Job`, `CoroutineContext`, `Dispatchers`
+- **`CoroutineContext`** is an indexed set of elements: `Job`, `CoroutineDispatcher`,
+  `CoroutineName`, `CoroutineExceptionHandler`. Combine with `+`.
+- **`Job`** — lifecycle handle (`isActive`, `isCancelled`, `isCompleted`); `cancel()`, `join()`,
+  parent/child hierarchy. `SupervisorJob()` gives unidirectional failure.
+- **Dispatchers**: `Default` (CPU-bound, threads = cores), `IO` (blocking IO, elastic pool,
+  shares threads with Default; use `.limitedParallelism(n)` to cap), `Main` (UI thread; needs a
+  platform module), `Unconfined` (starts in caller thread, resumes wherever — advanced/testing).
+
+### Cancellation (cooperative)
+- Cancellation throws **`CancellationException`** at the next suspension point. Code must be
+  *cooperative*: check `isActive`, call `ensureActive()`, or `yield()` in long CPU loops;
+  suspend functions from the library already cooperate.
+- **Never swallow `CancellationException`.** `try { … } catch (e: Exception) { }` around suspend
+  code will eat cancellation and break structured concurrency. Rethrow it, or catch specific
+  exceptions only. (A common correct guard: `catch (e: CancellationException) { throw e }`
+  before handling other exceptions.)
+- Clean up in `finally`; use `withContext(NonCancellable)` if you must suspend during cleanup.
+
+### Exception handling
+- `launch` → exception propagates up to the parent and (at the root) to the
+  **`CoroutineExceptionHandler`** or the platform default handler. `async` → exception held in
+  the `Deferred`, surfaced at `await()`.
+- **`CoroutineExceptionHandler` only fires for root coroutines** (roots of a scope /
+  `GlobalScope` / direct children of `supervisorScope`). Installing it on a child coroutine has
+  no effect — children delegate to their parent. You **cannot recover** in the handler; the
+  coroutine has already failed. It's a last-resort logger, not a `try/catch`.
+- **First exception wins**; further exceptions from siblings attach as *suppressed*.
+- `CancellationException` is transparent — ignored by handlers, does not cancel the parent.
+  A non-`CancellationException` from a child *does* cancel its parent (regular `Job`), and this
+  cannot be overridden — that's what `SupervisorJob`/`supervisorScope` exist to change.
+
+### Common pitfalls (reviewer checklist)
+- **`GlobalScope`** — unstructured, lives for the whole process, leaks. Flag almost every use;
+  prefer an injected scope or `coroutineScope`/`supervisorScope`.
+- **Blocking a dispatcher** — `Thread.sleep`, blocking JDBC/file IO, or heavy CPU on
+  `Dispatchers.Default`/`Main` without `withContext(Dispatchers.IO)`.
+- **Swallowed cancellation** — see above.
+- **`async` you never `await`** — the exception silently disappears.
+- **Launching without a parent scope**, or capturing a scope that outlives the work.
+
+---
+
+## 3. Flow (`kotlinx.coroutines.flow`)
+
+**`Flow<T>`** = a cold, asynchronous stream of values built on coroutines.
+
+### Cold flows
+- A `flow { }` builder's block does **not** run until a terminal operator collects it, and it
+  re-runs from scratch for each collector. Builders: `flow { emit(x) }`, `flowOf(a, b)`,
+  `iterable.asFlow()`.
+- `emit()` is a suspend call; emissions are sequential and honor backpressure automatically.
+
+### Operators
+- **Intermediate (cold, lazy):** `map`, `filter`, `transform` (emit 0..N per input), `take`,
+  `onEach`, `distinctUntilChanged`, `flatMapConcat` (sequential), `flatMapMerge` (concurrent),
+  `flatMapLatest` (cancel previous inner on new value). `zip`, `combine` for merging streams.
+- **Terminal (suspend):** `collect`, `toList`/`toSet`, `first`, `single`, `reduce`, `fold`,
+  `count`. `launchIn(scope)` collects in a scope without a `collect { }` body (pairs with
+  `onEach`).
+
+### Context, backpressure, completion
+- **`flowOn(ctx)`** — changes the context of *upstream* operators only (context-preserving);
+  the correct way to move producer work to `Dispatchers.IO`. Never call `withContext` inside a
+  `flow { }` to emit — that violates context preservation and throws.
+- **Backpressure:** `buffer(n)` (decouple producer/consumer), `conflate()` (keep only latest),
+  `collectLatest { }` (cancel the collector body when a new value arrives).
+- **Completion:** `onCompletion { cause -> }` runs on success or failure (`cause == null` on
+  success).
+
+### Exceptions
+- **Exception transparency** is the core rule: a flow must never emit from within a
+  `try/catch` that catches its own downstream exceptions. Handle upstream failures declaratively.
+- **`catch { }`** handles exceptions from *upstream only* (not from the collector); can emit a
+  fallback. **`retry(n) { predicate }`** / `retryWhen` restart the upstream on failure.
+
+### Hot flows: `StateFlow` vs `SharedFlow`
+- **`StateFlow<T>`** — hot, always has a current `value`, conflated, emits latest to new
+  collectors. State holder / observable value. `MutableStateFlow(initial)`. Equality-based
+  de-dup (won't re-emit an equal value).
+- **`SharedFlow<T>`** — hot, configurable `replay` and buffer, no initial value; for events.
+  `MutableSharedFlow(replay, extraBufferCapacity, onBufferOverflow)`.
+- **`stateIn(scope, started, initial)`** / **`shareIn(scope, started, replay)`** convert a cold
+  flow into a hot one shared across collectors. `started`: `SharingStarted.Eagerly`,
+  `.Lazily`, or `.WhileSubscribed(stopTimeoutMillis)` (the common choice — stops upstream when
+  no collectors, avoiding leaks).
+- Idiom: private `MutableStateFlow` backing a public read-only `StateFlow`
+  (`private val _s = MutableStateFlow(…); val s: StateFlow<T> = _s.asStateFlow()`).
+
+### Testing flows
+- `kotlinx-coroutines-test`: `runTest { }`, virtual time, `TestDispatcher`/`StandardTestDispatcher`,
+  `Dispatchers.setMain(...)`.
+- **Turbine** (community — Cash App / Square, *not* JetBrains) is the de-facto library for
+  asserting on flow emissions: `flow.test { assertEquals(1, awaitItem()); awaitComplete() }`.
+
+---
+
+## 4. Type system & classes
+
+- **`data class`** — auto `equals`/`hashCode`/`toString`/`componentN`/**`copy`**. Only
+  primary-constructor `val`/`var` participate. Enables **destructuring** (`val (a, b) = point`)
+  and non-destructive copy (`user.copy(name = "x")`). Reviewer note: don't put mutable `var`s or
+  non-value semantics in data classes carelessly.
+- **`sealed class` / `sealed interface`** (interfaces Stable since 1.5) — closed hierarchy known
+  at compile time; enables **exhaustive `when`** with no `else` (as an *expression*; 2.1 removed
+  redundant `else` even in some statement positions). The single most important tool for modeling
+  closed sets of states/results — flag `enum`+`when`-with-`else` or class hierarchies that should
+  be sealed.
+- **Value classes** `@JvmInline value class Meters(val v: Double)` (Stable since 1.5) — zero-cost
+  wrapper, inlined at runtime where possible (boxed when used as a generic/nullable/interface).
+  Great for type-safe primitives (`UserId`, `Email`). 2.2 adds `@JvmExposeBoxed` for Java interop.
+- **`enum class`** — finite set; can have members, implement interfaces, `entries` (Stable, via
+  `enumEntries<T>()` since 2.0 — replaces `values()`).
+- **`object`** (singleton) and **`companion object`** (per-class static-like holder; can
+  implement interfaces, be named, host factory functions and `@JvmStatic` members).
+- **Nested vs inner:** nested classes are static-like by default; **`inner`** captures the outer
+  instance (`this@Outer`).
+- **`open`/`final`/`abstract`** — classes and members are **`final` by default**; must mark
+  `open` to allow overriding. `visibility`: `public` (default), `internal` (module), `protected`,
+  `private`.
+- **Delegation `by`:**
+  - *Class delegation*: `class C(b: Base) : Base by b` — implement an interface by forwarding to
+    a member (composition over inheritance, no boilerplate).
+  - *Delegated properties*: `val x by lazy { … }` (thread-safe once by default),
+    `var y by Delegates.observable(init) { _, old, new -> }`, `var z by map` (map-backed),
+    `Delegates.vetoable`, and custom `getValue`/`setValue` operators.
+
+---
+
+## 5. Functions & functional style
+
+- **Top-level functions** (no class needed), **extension functions** (`fun String.shout() =
+  uppercase()` — resolved statically, not virtual), **infix** (`infix fun`), **operator**
+  (`operator fun plus`).
+- **Higher-order functions & lambdas** — function types `(A) -> B`, `A.(B) -> C` (receiver),
+  `it` for single param, **trailing-lambda** syntax (`list.map { it * 2 }`), named &
+  **default arguments** (reduces overloads).
+- **`inline` functions** — inline the lambda at the call site (no `Function` object allocation;
+  enables non-local returns and `reified`). Modifiers: **`noinline`** (don't inline a specific
+  lambda param), **`crossinline`** (inlined but forbids non-local return, e.g. when passed to
+  another execution context). Don't `inline` large functions — bytecode bloat.
+- **`reified` type parameters** — only in `inline` functions; makes `T` available at runtime:
+  `inline fun <reified T> Gson.fromJson(json: String): T = fromJson(json, T::class.java)`.
+- Function references: `::foo`, `String::length`, bound `instance::method`.
+
+---
+
+## 6. Generics
+
+- **Declaration-site variance:** `out T` (covariant, producer — `Source<out T>`), `in T`
+  (contravariant, consumer — `Comparable<in T>`). Compare to Java wildcards but declared once.
+- **Use-site variance (type projection):** `Array<out Any>`, `Array<in String>` at the use site
+  when the class itself is invariant.
+- **Star projection** `Foo<*>` — unknown type argument; read as `out Any?`, can't safely write.
+- **Upper bounds:** `<T : Comparable<T>>`; multiple bounds via **`where`**:
+  `fun <T> f(t: T) where T : CharSequence, T : Comparable<T>`.
+- **Reified generics** — see §5; the escape hatch from JVM type erasure (only in `inline` fns).
+
+---
+
+## 7. Idioms & stdlib
+
+- **Collections:** `map`/`filter`/`fold`/`reduce`/`groupBy`/`associate`/`associateBy`/
+  `flatMap`/`partition`/`sumOf`/`maxByOrNull`. Eager on `List`; use **`asSequence()`** for lazy,
+  short-circuiting pipelines over large data (avoids intermediate lists).
+- **Preconditions:** `require(cond) { msg }` (arg check → `IllegalArgumentException`),
+  `check(cond) { msg }` (state → `IllegalStateException`), `error(msg)` (→
+  `IllegalStateException`), `requireNotNull`/`checkNotNull` (smart-cast to non-null).
+- **`Result<T>`** — `runCatching { }`, `getOrNull`, `getOrElse`, `map`/`fold`, `onSuccess`/
+  `onFailure`. (Note: `Result` as a *return type* / parameter had historical restrictions;
+  fine for local flow control.)
+- **Ranges:** `1..10`, `1..<10` (`until`), `10 downTo 1`, `step`, `'a'..'z'`; work in `for` and
+  `in` checks.
+- **String templates:** `"Hello $name, ${user.age} yrs"`; raw strings `"""…"""` with
+  `.trimIndent()`.
+- **`when` / `if` as expressions** (return a value); **`Pair`/`Triple`** (`to` infix builds a
+  Pair) and destructuring (`val (k, v) = entry`).
+
+---
+
+## 8. KSP — Kotlin Symbol Processing
+
+- **What:** JetBrains/Google annotation-processing API that reads the **Kotlin AST directly**
+  and *generates* code (it can read but not modify existing source). Used by Room, Moshi, Dagger/
+  Hilt, Koin, etc.
+- **vs kapt:** kapt generates Java stubs then runs `javac` annotation processors — slow. KSP
+  works on Kotlin symbols directly, **~2× faster**, no stubs, Kotlin-native model.
+- **KSP2:** default since KSP `2.0.0` — a faster reimplementation with a cleaner API and better
+  standalone/CLI support. **KSP1 is deprecated from Kotlin 2.2** and cannot support new language
+  features — advise migrating. **kapt is legacy**; migrate to KSP where processors support it
+  (K2 kapt exists — `kapt.use.k2=true` — but is a bridge, not the destination).
+- **Writing a processor:** implement `SymbolProcessor` + `SymbolProcessorProvider`, register via
+  `resolver.getSymbolsWithAnnotation(...)`, visit with `KSVisitor`, emit via `CodeGenerator`.
+  Consuming = add the processor with the `ksp(...)` Gradle configuration. (Build-system depth is
+  another agent's concern.)
+
+---
+
+## 9. Java interop
+
+- **Calling Java from Kotlin** — mostly transparent; getters/setters become properties; Java
+  types without nullability info become **platform types `T!`** (relaxed null checking — the
+  main interop hazard; annotate with JSpecify/`@Nullable`/`@NotNull`, which K2 enforces).
+- **SAM conversion** — pass a lambda where Java expects a single-abstract-method interface:
+  `executor.execute { … }`. (Kotlin interfaces need `fun interface` to get SAM conversion.)
+- **Calling Kotlin from Java — the annotation toolkit:**
+  - `@JvmStatic` — emit a real static method (on companion/object members).
+  - `@JvmOverloads` — generate overloads for default parameters so Java can call them.
+  - `@JvmField` — expose a field directly (no getter/setter).
+  - `@JvmName("…")` — rename the JVM symbol (resolve clashes, e.g. same erasure).
+  - `@Throws(IOException::class)` — declare checked exceptions for Java callers (Kotlin has no
+    checked exceptions).
+  - `@file:JvmName` / `@JvmMultifileClass` — control the generated file-facade class name.
+- **Checked exceptions:** Kotlin doesn't have them — a Kotlin function can throw anything;
+  use `@Throws` at the Java boundary.
+
+---
+
+## 10. Kotlin Multiplatform (KMP) — basics
+
+- **Purpose:** share business logic (networking, serialization, domain, validation) across
+  platforms while keeping native UI per platform. Not "write once run anywhere" for UI (that's
+  Compose Multiplatform, a separate concern).
+- **Source sets:** `commonMain` (platform-agnostic code + common APIs) plus platform source sets
+  (`jvmMain`, `androidMain`, `iosMain`, `jsMain`, `nativeMain`, `wasmJsMain`).
+- **Targets:** JVM, Android, iOS/macOS/watchOS/tvOS (Kotlin/Native), JS, Native (Linux/Windows),
+  **Wasm** (`wasmJs`/`wasmWasi`, evolving).
+- **`expect`/`actual`** — declare an API in common (`expect fun platformName(): String`) and
+  provide a per-platform implementation (`actual fun platformName() = "JVM"`). Works for
+  functions, classes, properties, typealiases. In 2.0+, `actual` may be *more* permissive in
+  visibility than `expect`, and common/platform source resolution is strictly separated (common
+  code cannot accidentally resolve to a platform overload).
+- KMP itself is **Stable**; individual targets/libraries vary (Wasm younger than JVM/iOS).
+
+---
+
+## 11. Idioms, anti-patterns & "language debt" — reviewer's checklist
+
+A `language-kotlin-expert` should scan for and flag:
+
+1. **`!!` density** — each is a latent NPE and a defeated type system. Replace with `?.`/`?:`/
+   `requireNotNull`/restructuring.
+2. **`GlobalScope`** — unstructured concurrency; leaks. Demand a real scope.
+3. **Blocking calls on a coroutine dispatcher** — `Thread.sleep`, blocking IO/JDBC, heavy CPU on
+   `Default`/`Main` without `withContext(Dispatchers.IO/Default)`.
+4. **Swallowing `CancellationException`** — broad `catch (Exception)` in suspend code; must
+   rethrow cancellation.
+5. **Overusing platform types** — not annotating Java boundaries; nullable data flowing in
+   unchecked.
+6. **`lateinit` misuse** — using it for values that could be nullable or should be `val`;
+   `lateinit` on primitives is illegal and it throws `UninitializedPropertyAccessException` if
+   read early. Prefer constructor injection or `by lazy`.
+7. **Stringly-typed code** — passing `String`/`Int` where a value class, enum, or sealed type
+   would encode the domain.
+8. **Not using sealed classes for closed hierarchies** — `when` with an `else` that "shouldn't
+   happen", or `enum` + external state, instead of a sealed hierarchy giving compile-time
+   exhaustiveness.
+9. **Nullable-everywhere** — `T?` fields that are really always set; push nullability to the edges.
+10. **Scope-function abuse** — nested/chained `let`/`apply`/`run`/`also` where `this`/`it` is
+    ambiguous; `apply` used where a plain constructor call would do.
+11. **Mutable shared state across coroutines** without synchronization (`Mutex`, confinement,
+    `StateFlow`).
+12. **Eager collection chains over large data** where a `Sequence` avoids intermediate allocations.
+13. **`data class` misuse** — mutable `var`s, or entities where identity ≠ structural equality.
+14. **`async` without `await`**, or launching work in a scope that outlives its owner.
+
+---
+
+## Sources
+
+### Official (kotlinlang.org / JetBrains)
+- What's new in Kotlin 2.2 — https://kotlinlang.org/docs/whatsnew22.html
+- What's new in Kotlin 2.1 — https://kotlinlang.org/docs/whatsnew21.html
+- What's new in Kotlin 2.0 — https://kotlinlang.org/docs/whatsnew20.html
+- Null safety — https://kotlinlang.org/docs/null-safety.html
+- Coroutine exception handling — https://kotlinlang.org/docs/exception-handling.html
+- Asynchronous Flow — https://kotlinlang.org/docs/coroutines-flow.html
+- KSP FAQ / overview — https://kotlinlang.org/docs/ksp-faq.html , https://kotlinlang.org/docs/ksp-overview.html
+- (Reference, not re-fetched this pass but authoritative for their topics) Coroutines guide —
+  https://kotlinlang.org/docs/coroutines-guide.html ; Scope functions —
+  https://kotlinlang.org/docs/scope-functions.html ; Sealed classes —
+  https://kotlinlang.org/docs/sealed-classes.html ; Inline value classes —
+  https://kotlinlang.org/docs/inline-classes.html ; Generics —
+  https://kotlinlang.org/docs/generics.html ; Java interop —
+  https://kotlinlang.org/docs/java-to-kotlin-interop.html ; KMP —
+  https://kotlinlang.org/docs/multiplatform.html
+- `kotlinx.coroutines` API docs — https://kotlinlang.org/api/kotlinx.coroutines/
+
+### Community (verify independently; NOT JetBrains)
+- Turbine (Cash App / Square) — Flow testing library — https://github.com/cashapp/turbine
+- Android Developers "Migrate from kapt to KSP" (Google, Android-focused) —
+  https://developer.android.com/build/migrate-to-ksp
+
+> Version-sensitivity flags carried inline throughout §0. Recheck any Preview/Beta/Experimental
+> feature (context parameters, context-sensitive resolution, nested type aliases, `@all:`,
+> `@JvmExposeBoxed`, explicit backing fields) against the *exact* Kotlin version in the target
+> project before advising it as production-ready.

--- a/research/kotlin-language/README.md
+++ b/research/kotlin-language/README.md
@@ -1,0 +1,14 @@
+# Kotlin Language — Research Reference
+
+Grounds the [`language-kotlin-expert`](../../agents/sdlc/language-kotlin-expert.md) agent (feature #228,
+Android sub-epic #225). Compiled 2026-07-23 from kotlinlang.org / JetBrains. Kotlin ships an incremental
+release train (2.0 May 2024, 2.1 Nov 2024, 2.2 mid-2025); every Preview/Beta/Experimental feature is
+tagged with its opt-in flag and first-availability version — re-check against the target project's exact
+Kotlin version. Scope is the **language + coroutines/stdlib**, not the Android framework. Community tools
+(Turbine) are labelled non-JetBrains.
+
+| File | Covers |
+|------|--------|
+| [`01-kotlin-language.md`](01-kotlin-language.md) | K2 compiler & 2.x feature-availability matrix, null-safety & scope functions, coroutines & structured concurrency (dispatchers/cancellation/exception handling), Flow (StateFlow/SharedFlow, operators, flowOn, stateIn), type system (data/sealed/value classes, delegation), functions (inline/reified, extensions), generics/variance, stdlib idioms, KSP (KSP2), Java interop, KMP basics, idioms/anti-patterns/"language debt" |
+
+**At a glance:** K2 is default since 2.0 (wider smart-casts); guard conditions / non-local break-continue / multi-dollar interpolation are Stable in 2.2 (preview in 2.1); context parameters are 2.2 Preview (replace deprecated context receivers); never swallow `CancellationException`; `CoroutineExceptionHandler` fires only for roots; Flow exception transparency + `flowOn` context-preservation; KSP2 default (KSP1 deprecated from 2.2); top review smells — `!!` density, `GlobalScope`, blocking a dispatcher, stringly-typed code, non-sealed closed hierarchies.

--- a/retrospectives/228-sdlc-lang-kotlin.md
+++ b/retrospectives/228-sdlc-lang-kotlin.md
@@ -1,0 +1,56 @@
+# Retrospective: sdlc-lang-kotlin (language-kotlin-expert)
+
+**Branch:** `feature/sdlc-lang-kotlin`
+**Date:** 2026-07-23
+**Duration:** ~1 session (research + agent + wiring)
+
+---
+
+## Summary
+
+Phase 2 of the Android sub-epic (#225): adding the `sdlc-lang-kotlin` plugin with `language-kotlin-expert`,
+completing the language-plugin family (`python`/`javascript`/`swift`/`kotlin`) and mirroring
+`sdlc-lang-swift`. Delivered with all validators green and 815 tests passing.
+
+## What Went Well
+
+- **Direct Swift precedent**: `sdlc-lang-swift` made the plugin shape, boundary split, and setup-team
+  wiring mechanical — scaffolding was done while research ran, and the marketplace edits were clean
+  one-liners (no json.dump reformat this time).
+- **Current, version-tagged research**: the Kotlin reference tagged every 2.x feature Stable/Preview with
+  its opt-in flag (guard conditions Stable in 2.2, context parameters 2.2 preview replacing deprecated
+  context receivers), so the agent's guidance is precise about K2/version status.
+- **The Android agents already referenced it**: I''d written the Android platform agents to route
+  "Kotlin-the-language → language-kotlin-expert", so those cross-references resolved the moment the agent
+  landed — no back-edits needed.
+
+## What Could Improve
+
+- Nothing notable — the language-plugin playbook (Swift → Kotlin) is now fully routine: research → agent
+  → wire → validate → PR, clean first pass.
+
+## Lessons Learned
+
+1. **Forward-referencing pays off.** Writing the Android agents'' boundaries to name the not-yet-built
+   `language-kotlin-expert` meant zero rework when it shipped.
+2. **Symmetry compounds.** Each language plugin (swift, now kotlin) gets faster because the shape,
+   boundaries, setup-team wiring, and docs are identical to the last.
+
+## Changes Made
+
+### Files Created
+- `docs/feature-proposals/228-sdlc-lang-kotlin.md`, `retrospectives/228-sdlc-lang-kotlin.md`
+- `plugins/sdlc-lang-kotlin/` (plugin.json, README, agents/) + `agents/sdlc/language-kotlin-expert.md`
+- `research/kotlin-language/` (reference + README)
+
+### Files Modified
+- `release-mapping.yaml` — sdlc-lang-kotlin section
+- `.claude-plugin/marketplace.json` — +sdlc-lang-kotlin; sdlc-core → 1.4.0
+- `plugins/sdlc-core/.claude-plugin/plugin.json` → 1.4.0
+- `skills/setup-team/SKILL.md` (+ plugin copy) — recommend sdlc-lang-kotlin for Android/cross-platform
+- `CLAUDE.md`, `README.md` — plugin tables/counts
+
+## Action Items
+
+- [ ] Complete `language-kotlin-expert` from research; cross-reference Android agents; regenerate catalog; validate; PR
+- [ ] Phase 3 of #225: Android skills (scaffold/signing/play-release/ci) + validators

--- a/skills/setup-team/SKILL.md
+++ b/skills/setup-team/SKILL.md
@@ -108,8 +108,8 @@ Look for `.sdlc/team-config.json` in the project root (or `.claude/team-config.j
    | D. API | `sdlc-team-common`, `sdlc-team-fullstack`, `sdlc-team-cloud` |
    | E. Security | `sdlc-team-common`, `sdlc-team-security` |
    | G. iOS app | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-mobile`, `sdlc-lang-swift` |
-   | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile` |
-   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift` |
+   | H. Android app | `sdlc-team-common`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-kotlin` |
+   | I. Cross-platform mobile | `sdlc-team-common`, `sdlc-team-ios`, `sdlc-team-android`, `sdlc-team-mobile`, `sdlc-lang-swift`, `sdlc-lang-kotlin` |
    | F. Custom | `sdlc-team-common` (pre-selected) + user picks additional team plugins |
 
    **Mobile plugins pair with the shared base.** `sdlc-team-ios` (Apple HIG) and `sdlc-team-android` (Material Design 3) each carry only their platform's design specialist; the cross-platform agents (`mobile-architect`, `mobile-ux-architect`) live once in `sdlc-team-mobile`. Always recommend the platform plugin **and** `sdlc-team-mobile` together — the marketplace has no hard dependency resolution, so this recommendation is the pairing mechanism. A cross-platform team installs both platform plugins + the single shared base (agents are never duplicated).


### PR DESCRIPTION
**Part of #225 (Android sub-epic) / #217 (EPIC). Closes #228.** Phase 2 of the Android build-out.

## Summary

Adds the **`sdlc-lang-kotlin`** plugin with **`language-kotlin-expert`**, completing the language-plugin family — `sdlc-lang-python` / `-javascript` / `-swift` / **`-kotlin`**. Resolves the Kotlin-placement question the same way as Swift: a **dedicated language plugin** (Kotlin is also server-side / KMP), not bundled into `sdlc-team-android`.

Grounded in kotlinlang.org deep research (Kotlin 2.x, K2 compiler), with every feature version-tagged (guard conditions Stable in 2.2, context parameters 2.2 preview replacing deprecated context receivers, KSP2 default / KSP1 deprecated from 2.2).

## The agent (`language-kotlin-expert`)

Idiomatic Kotlin 2.x — the **language**, not the Android framework:
- Null-safety & scope functions; **coroutines & structured concurrency** (dispatchers, cooperative cancellation, `CoroutineExceptionHandler` fires only for roots); **Flow** (StateFlow vs SharedFlow, `flowOn` context-preservation, exception transparency, `stateIn` + `WhileSubscribed`)
- Type system (data/sealed/value classes, delegation), functions (inline/reified, extensions), generics/variance, stdlib idioms, KSP, Java interop, KMP basics
- Review checklist: `!!` density, `GlobalScope`, blocking a dispatcher, swallowed `CancellationException`, stringly-typed code, non-sealed closed hierarchies

Clean boundary: `language-kotlin-expert` = the language; `android-app-architect` / `jetpack-compose-architect` = the Android framework. The Android agents already route Kotlin-the-language here — **cross-references resolved with no back-edits**.

## Both mobile platforms now have full symmetry
- **iOS**: `sdlc-team-ios` (4 agents + skills + pre-flight) + `sdlc-lang-swift`
- **Android**: `sdlc-team-android` (6 agents) + **`sdlc-lang-kotlin`**

Remaining in sub-epic #225: **Phase 3** — Android skills + validators (scaffold/signing/play-release/ci; manifest/SDK-policy/release-config checks).

## Wiring
release-mapping (+plugin) · marketplace (+plugin; `sdlc-core` 1.3.0 → **1.4.0** for the setup-team recommendation) · setup-team matrix recommends `sdlc-lang-kotlin` for Android/cross-platform · AGENT-INDEX/CATALOG regenerated (19 plugins, 17 ship agents) · READMEs + CLAUDE.md.

## Validation
- Full suite **(815) passes**; `validate-agent-format` + `validate-agent-official` PASS
- `check-plugin-packaging` PASS (19 plugins); `check-technical-debt .` COMPLIANT; `check-broken-references` clean; non-ASCII scan clean
- `check-feature-proposal` properly formatted; plugin ↔ marketplace versions agree

Agent/research markdown + JSON/YAML only — no application code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)